### PR TITLE
upgrade mongock from 4.1.x to 4.3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.5.7</version>
-        <relativePath/>
+        <relativePath />
     </parent>
 
     <groupId>eu.dzhw.fdz</groupId>
@@ -47,6 +47,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.github.cloudyrock.mongock</groupId>
+                <artifactId>mongock-bom</artifactId>
+                <version>4.3.8</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -62,12 +69,10 @@
         <dependency>
             <groupId>com.github.cloudyrock.mongock</groupId>
             <artifactId>mongock-spring-v5</artifactId>
-            <version>4.1.19</version>
         </dependency>
         <dependency>
             <groupId>com.github.cloudyrock.mongock</groupId>
             <artifactId>mongodb-springdata-v3-driver</artifactId>
-            <version>4.1.19</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
@@ -406,7 +411,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -419,7 +424,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -432,7 +437,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -445,7 +450,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -49,6 +49,15 @@ mongock:
   change-logs-scan-package:
     - eu.dzhw.fdz.metadatamanagement.common.repository.changelogs
     - eu.dzhw.fdz.metadatamanagement.usermanagement.repository.changelogs
+  # necessary config due to mongock upgrade from 4.1.x to 4.3.x
+  # see: https://github.com/mongock/mongock/issues/294
+  mongo-db:
+    write-concern:
+      w: majority
+      w-timeout-ms: 300000
+      journal: false
+    read-concern: local
+    read-preference: primary
     
 logging:
     level:


### PR DESCRIPTION
The intended upgrade to 4.3.6 in #3075 does not work due to changes in mongock when connecting to the embedded mongodb used in unittests. In version 4.3.7 they have addressed this issue and added several configuration options.

Closes #3075, closes #3098