### PR TITLE
update aws sdk to 1.12.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.708</version>
+                <version>1.12.313</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
AWS SDK for Java 1.11.x is no longer maintained.

see https://github.com/aws/aws-sdk-java#supported-minor-versions

Closes #3071, closes #3090 