### PR TITLE
#3166: fixed disappearing for hints that dont have error messages

### DIFF
--- a/src/main/webapp/scripts/analysispackagemanagement/components/externaldatapackage/external.html.tmpl
+++ b/src/main/webapp/scripts/analysispackagemanagement/components/externaldatapackage/external.html.tmpl
@@ -73,7 +73,8 @@
            md-maxlength="2000"
            ng-model="$ctrl.package.dataSourceUrl" autocomplete="off">
     <div class="fdz-input-hint"
-         ng-if="!$ctrl.currentForm['analysisDataPackagesDataSourceUrl_' + $ctrl.index].$dirty && !$ctrl.currentForm['analysisDataPackagesDataSourceUrl_' + $ctrl.index].$touched">
+         ng-if="$ctrl.currentForm['analysisDataPackagesDataSourceUrl_' + $ctrl.index].$viewValue == null 
+          || $ctrl.currentForm['analysisDataPackagesDataSourceUrl_' + $ctrl.index].$viewValue == ''">
       {{ 'analysis-package-management.edit.hints.external-data-package.data-source-url' | translate}}
     </div>
     <div multiple

--- a/src/main/webapp/scripts/analysispackagemanagement/views/analysis-package-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/analysispackagemanagement/views/analysis-package-edit-or-create.html.tmpl
@@ -43,7 +43,7 @@
                         ng-model="ctrl.analysisPackage.annotations.de"
                         rows="4"></textarea>
               <div class="fdz-input-hint"
-                   ng-if="!analysisPackageForm.annotationsDe.$dirty && !analysisPackageForm.annotationsDe.$touched">
+                   ng-if="ctrl.analysisPackage.annotations.de == null || ctrl.analysisPackage.annotations.de == ''">
                 {{'analysis-package-management.edit.hints.annotations.de' | translate}}
               </div>
               <div multiple
@@ -65,7 +65,7 @@
                         ng-model="ctrl.analysisPackage.annotations.en"
                         rows="4"></textarea>
               <div class="fdz-input-hint"
-                   ng-if="!analysisPackageForm.annotationsEn.$dirty && !analysisPackageForm.annotationsEn.$touched">
+                   ng-if="ctrl.analysisPackage.annotations.en == null || ctrl.analysisPackage.annotations.en == ''">
                 {{'analysis-package-management.edit.hints.annotations.en' | translate}}
               </div>
               <div multiple
@@ -395,7 +395,6 @@
                       tags="ctrl.analysisPackage.tags"></tag-editor>
         </md-card-content>
       </md-card>
-
       <url-component
         current-form="analysisPackageForm"
         content="ctrl.analysisPackage.additionalLinks"

--- a/src/main/webapp/scripts/common/dialogs/attachment/attachment-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/common/dialogs/attachment/attachment-edit-or-create.html.tmpl
@@ -112,7 +112,7 @@
               <input fdz-required="!ctrl.attachmentMetadata.description.de" md-maxlength="512" ng-model="ctrl.attachmentMetadata.description.en" name="descriptionEn" lang="en" md-no-asterisk>
               <div ng-if="!attachmentForm.descriptionEn.$dirty && !attachmentForm.descriptionEn.$touched" class="fdz-input-hint">{{'attachment.hint.description.en' | translate}}</div>
               <div ng-messages="attachmentForm.descriptionEn.$error" multiple>
-                <div ng-message="fdz-required">{{'atthiuzguachment.error.description.i18n-string-not-empty' | translate}}</div>
+                <div ng-message="fdz-required">{{'attachment.error.description.i18n-string-not-empty' | translate}}</div>
                 <div ng-message="md-maxlength">{{'attachment.error.description.i18n-string-size' | translate}}</div>
               </div>
             </md-input-container>
@@ -121,7 +121,7 @@
             <md-input-container flex="50" class="ms-flex" md-is-error="!attachmentForm.doi.$valid && (attachmentForm.doi.$dirty || attachmentForm.doi.$touched)">
               <label>{{'attachment.label.doi' | translate}}</label>
               <input ng-pattern="/^https:\/\/doi.org\/?([_A-Za-z0-9äöüÄÖÜß\-\/\:.]{2,}$)/" md-maxlength="512" name="doi" ng-model="ctrl.attachmentMetadata.doi">
-              <div class="fdz-input-hint" ng-if="!attachmentForm.doi.$dirty && !attachmentForm.doi.$touched" >
+              <div class="fdz-input-hint" ng-if="ctrl.attachmentMetadata.doi == null || ctrl.attachmentMetadata.doi == ''">
                 {{'attachment.hint.doi' | translate}}
               </div>
               <div multiple ng-messages="attachmentForm.doi.$error">

--- a/src/main/webapp/scripts/common/people/edit-people.html.tmpl
+++ b/src/main/webapp/scripts/common/people/edit-people.html.tmpl
@@ -41,7 +41,7 @@
                  autocomplete="off">
           <div
             class="fdz-input-hint"
-            ng-if="!form[$ctrl.peopleId + 'MiddleName_' + $index].$dirty && !form[$ctrl.peopleId + 'MiddleName_' + $index].$touched">
+            ng-if="person.middleName == null || person.middleName == ''">
             {{ $ctrl.translationKeys.hints.middleName | translate}}
           </div>
           <div multiple ng-messages="form[$ctrl.peopleId + 'MiddleName_' + $index].$error">

--- a/src/main/webapp/scripts/common/text/text-bilingual.html.tmpl
+++ b/src/main/webapp/scripts/common/text/text-bilingual.html.tmpl
@@ -17,7 +17,11 @@
     rows="4"></textarea>
   <div
     class="fdz-input-hint"
-    ng-if="!$ctrl.currentForm[$ctrl.controlName + 'De_' + $ctrl.index].$dirty && !$ctrl.currentForm[$ctrl.controlName + 'De_' + $ctrl.index].$touched">
+    ng-if="(
+      (!$ctrl.notNull && ($ctrl.content.de == null || $ctrl.content.de == '')) ||
+      ($ctrl.notNull && !$ctrl.currentForm[$ctrl.controlName + 'De_' + $ctrl.index].$dirty 
+        && !$ctrl.currentForm[$ctrl.controlName + 'De_' + $ctrl.index].$touched)
+      )">
     {{$ctrl.translationKeyManagement + '.edit.hints.' + $ctrl.translationKeyPackage + '.' + $ctrl.translationKeyName + '.de' | translate}}
   </div>
   <div multiple
@@ -51,7 +55,11 @@
     rows="4"></textarea>
   <div
     class="fdz-input-hint"
-    ng-if="!$ctrl.currentForm[$ctrl.controlName + 'En_' + $ctrl.index].$dirty && !$ctrl.currentForm[$ctrl.controlName + 'En_' + $ctrl.index].$touched">
+    ng-if="(
+      (!$ctrl.notNull && ($ctrl.content.en == null || $ctrl.content.en == '')) ||
+      ($ctrl.notNull && !$ctrl.currentForm[$ctrl.controlName + 'En_' + $ctrl.index].$dirty 
+        && !$ctrl.currentForm[$ctrl.controlName + 'En_' + $ctrl.index].$touched)
+      )">
     {{$ctrl.translationKeyManagement + '.edit.hints.' + $ctrl.translationKeyPackage + '.' + $ctrl.translationKeyName + '.en' | translate}}
   </div>
   <div

--- a/src/main/webapp/scripts/common/textsection/edit-text-section.html.tmpl
+++ b/src/main/webapp/scripts/common/textsection/edit-text-section.html.tmpl
@@ -28,7 +28,7 @@
                   rows="4"></textarea>
         <div
           class="fdz-input-hint"
-          ng-if="!$ctrl.currentForm[$ctrl.translationKeyName].$dirty && !$ctrl.currentForm[$ctrl.translationKeyName].$touched">
+          ng-if="$ctrl.content == null || $ctrl.content == ''">
           {{$ctrl.translationKeyPackage + '-management.edit.hints.' + $ctrl.translationKeyName | translate}}
         </div>
         <div

--- a/src/main/webapp/scripts/common/url/additional-links.html.tmpl
+++ b/src/main/webapp/scripts/common/url/additional-links.html.tmpl
@@ -58,7 +58,7 @@
                ng-model="link.displayText.de" autocomplete="off">
         <div
           class="fdz-input-hint"
-          ng-if="!$ctrl.currentForm['linkDisplayTextDe_' + $index].$dirty && !$ctrl.currentForm['linkDisplayTextDe_' + $index].$touched">
+          ng-if="link.displayText.de == null || link.displayText.de == ''">
           {{ 'analysis-package-management.edit.hints.additional-links.display-text.de' | translate}}
         </div>
         <div multiple
@@ -79,7 +79,7 @@
                ng-model="link.displayText.en" autocomplete="off">
         <div
           class="fdz-input-hint"
-          ng-if="!$ctrl.currentForm['linkDisplayTextEn_' + $index].$dirty && !$ctrl.currentForm['linkDisplayTextEn_' + $index].$touched">
+          ng-if="link.displayText.en == null || link.displayText.en == ''">
           {{ 'analysis-package-management.edit.hints.additional-links.display-text.en' | translate}}
         </div>
         <div multiple

--- a/src/main/webapp/scripts/conceptmanagement/views/concept-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/conceptmanagement/views/concept-edit-or-create.html.tmpl
@@ -87,7 +87,7 @@
             <md-input-container flex="50" md-is-error="!conceptForm.doi.$valid && (conceptForm.doi.$dirty || conceptForm.doi.$touched)" class="ms-flex">
               <label>{{'concept-management.detail.label.doi' | translate}}</label>
               <input md-maxlength="512" name="doi" ng-model="ctrl.concept.doi">
-              <div class="fdz-input-hint" ng-if="!conceptForm.doi.$dirty && !conceptForm.doi.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.concept.doi == null || ctrl.concept.doi == ''">
                 {{'concept-management.edit.hints.doi' | translate}}
               </div>
               <div multiple ng-messages="conceptForm.doi.$error">
@@ -162,7 +162,7 @@
           <md-input-container md-is-error="!conceptForm.license.$valid && (conceptForm.license.$dirty || conceptForm.license.$touched)" class="ms-flex w-100">
             <label>{{'concept-management.detail.label.license-edit' | translate}}<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
             <textarea md-maxlength="1048576" name="license" ng-model="ctrl.concept.license" ng-trim="true" rows="4"></textarea>
-            <div class="fdz-input-hint" ng-if="!conceptForm.license.$dirty && !conceptForm.license.$touched">
+            <div class="fdz-input-hint" ng-if="ctrl.concept.license == null || ctrl.concept.license == ''">
               {{'concept-management.edit.hints.license' | translate}}
             </div>
             <div multiple ng-messages="conceptForm.license.$error">

--- a/src/main/webapp/scripts/datapackagemanagement/configuration/translations-de.js
+++ b/src/main/webapp/scripts/datapackagemanagement/configuration/translations-de.js
@@ -183,7 +183,7 @@ angular.module('metadatamanagementApp').config(
               }
             },
             'additional-links': {
-              'invalid-url': 'Die angegebene URL ist ungültig',
+              'invalid-url': 'Die angegebene URL ist ungültig (korrektes Beispiel: https://www.dzhw.eu)',
               'url-size': 'Die Maximallänge der URL ist 2000 Zeichen.',
               'url-not-empty': 'Die URL darf nicht leer sein.',
               'display-text-size': 'Die Maximallänge des Anzeigetextes ist 512 Zeichen.'

--- a/src/main/webapp/scripts/datapackagemanagement/views/data-package-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/datapackagemanagement/views/data-package-edit-or-create.html.tmpl
@@ -76,7 +76,7 @@
               <md-not-found>
                 {{'search-management.filter.study-series-filter.not-found' | translate}}
               </md-not-found>
-              <div class="fdz-input-hint" ng-if="!dataPackageForm.studySeriesDe.$dirty && !dataPackageForm.studySeriesDe.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.dataPackage.studySeries.de == null || ctrl.dataPackage.studySeries.de == ''">
                 {{'data-package-management.edit.hints.study-series.de' | translate}}
               </div>
               <div multiple ng-messages="dataPackageForm.studySeriesDe.$error">
@@ -110,7 +110,7 @@
               <md-not-found>
                 {{'search-management.filter.study-series-filter.not-found' | translate}}
               </md-not-found>
-              <div class="fdz-input-hint" ng-if="!dataPackageForm.studySeriesEn.$dirty && !dataPackageForm.studySeriesEn.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.dataPackage.studySeries.en == null || ctrl.dataPackage.studySeries.en == ''">
                 {{'data-package-management.edit.hints.study-series.en' | translate}}
               </div>
               <div multiple ng-messages="dataPackageForm.studySeriesEn.$error">
@@ -156,7 +156,7 @@
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="de" md-maxlength="2048" name="annotationsDe" ng-model="ctrl.dataPackage.annotations.de"
                         rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!dataPackageForm.annotationsDe.$dirty && !dataPackageForm.annotationsDe.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.dataPackage.annotations.de == null || ctrl.dataPackage.annotations.de == ''">
                 {{'data-package-management.edit.hints.annotations.de' | translate}}
               </div>
               <div class="fdz-input-hint">
@@ -180,7 +180,7 @@
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="en" md-maxlength="2048" name="annotationsEn" ng-model="ctrl.dataPackage.annotations.en"
                         rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!dataPackageForm.annotationsEn.$dirty && !dataPackageForm.annotationsEn.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.dataPackage.annotations.en == null || ctrl.dataPackage.annotations.en == ''">
                 {{'data-package-management.edit.hints.annotations.en' | translate}}
               </div>
               <div class="fdz-input-hint">
@@ -581,7 +581,7 @@
                      ng-model="link.displayText.de" autocomplete="off">
               <div
                 class="fdz-input-hint"
-                ng-if="!dataPackageForm['linkDisplayTextDe_' + $index].$dirty && !dataPackageForm['linkDisplayTextDe_' + $index].$touched">
+                ng-if="link.displayText.de == null || link.displayText.de == ''">
                 {{ 'data-package-management.edit.hints.additional-links.display-text.de' | translate}}
               </div>
               <div multiple ng-messages="dataPackageForm['linkDisplayTextDe_' + $index].$error">
@@ -596,7 +596,7 @@
                      ng-model="link.displayText.en" autocomplete="off">
               <div
                 class="fdz-input-hint"
-                ng-if="!dataPackageForm['linkDisplayTextEn_' + $index].$dirty && !dataPackageForm['linkDisplayTextEn_' + $index].$touched">
+                ng-if="link.displayText.en == null || link.displayText.en == ''">
                 {{ 'data-package-management.edit.hints.additional-links.display-text.en' | translate}}
               </div>
               <div multiple ng-messages="dataPackageForm['linkDisplayTextEn_' + $index].$error">

--- a/src/main/webapp/scripts/datasetmanagement/views/data-set-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/datasetmanagement/views/data-set-edit-or-create.html.tmpl
@@ -53,7 +53,7 @@
               <md-select name="format" ng-model="ctrl.dataSet.format" ng-model-options="{trackBy: '$value.de'}">
                 <md-option ng-repeat="format in ctrl.formats" ng-value="format">{{format[currentLanguage]}}</md-option>
               </md-select>
-              <div class="fdz-input-hint" ng-if="!dataSetForm.format.$dirty && !dataSetForm.format.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.dataSet.format == null || ctrl.dataSet.format == ''">
                 {{'data-set-management.edit.hints.format' | translate}}
               </div>
               <div multiple ng-messages="dataSetForm.format.$error">
@@ -113,7 +113,7 @@
               <label>{{'data-set-management.detail.label.annotations' | translate}} ({{'global.in-german' |
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="de" md-maxlength="2048" md-no-asterisk name="annotationsDe" ng-model="ctrl.dataSet.annotations.de" rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!dataSetForm.annotationsDe.$dirty && !dataSetForm.annotationsDe.$touched">{{'data-set-management.edit.hints.annotations.de' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.dataSet.annotations.de == null || ctrl.dataSet.annotations.de == ''">{{'data-set-management.edit.hints.annotations.de' | translate}}
               </div>
               <div multiple ng-messages="dataSetForm.annotationsDe.$error">
                 <div ng-message="md-maxlength">{{'data-set-management.error.data-set.annotations.i18n-string-size' |
@@ -125,7 +125,7 @@
               <label>{{'data-set-management.detail.label.annotations' | translate}} ({{'global.in-english' |
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="en" md-maxlength="2048" md-no-asterisk name="annotationsEn" ng-model="ctrl.dataSet.annotations.en" rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!dataSetForm.annotationsEn.$dirty && !dataSetForm.annotationsEn.$touched">{{'data-set-management.edit.hints.annotations.en' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.dataSet.annotations.en == null || ctrl.dataSet.annotations.en == ''">{{'data-set-management.edit.hints.annotations.en' | translate}}
               </div>
               <div multiple ng-messages="dataSetForm.annotationsEn.$error">
                 <div ng-message="md-maxlength">{{'data-set-management.error.data-set.annotations.i18n-string-size' |

--- a/src/main/webapp/scripts/instrumentmanagement/views/instrument-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/instrumentmanagement/views/instrument-edit-or-create.html.tmpl
@@ -86,7 +86,7 @@
               <label>{{'instrument-management.detail.label.subtitle' | translate}} ({{'global.in-german' |
                 translate}})</label>
               <input lang="de" md-maxlength="2048" md-no-asterisk name="subtitleDe" ng-model="ctrl.instrument.subtitle.de">
-              <div class="fdz-input-hint" ng-if="!instrumentForm.subtitleDe.$dirty && !instrumentForm.subtitleDe.$touched">{{'instrument-management.edit.hints.subtitle.de' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.instrument.subtitle.de == null || ctrl.instrument.subtitle.de == ''">{{'instrument-management.edit.hints.subtitle.de' | translate}}
               </div>
               <div multiple ng-messages="instrumentForm.subtitleDe.$error">
                 <div ng-message="md-maxlength">{{'instrument-management.error.instrument.subtitle.i18n-string-size' |
@@ -98,7 +98,7 @@
               <label>{{'instrument-management.detail.label.subtitle' | translate}} ({{'global.in-english' |
                 translate}})</label>
               <input lang="en" md-maxlength="2048" md-no-asterisk name="subtitleEn" ng-model="ctrl.instrument.subtitle.en">
-              <div class="fdz-input-hint" ng-if="!instrumentForm.subtitleEn.$dirty && !instrumentForm.subtitleEn.$touched">{{'instrument-management.edit.hints.subtitle.en' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.instrument.subtitle.en == null || ctrl.instrument.subtitle.en == ''">{{'instrument-management.edit.hints.subtitle.en' | translate}}
               </div>
               <div multiple ng-messages="instrumentForm.subtitleEn.$error">
                 <div ng-message="md-maxlength">{{'instrument-management.error.instrument.subtitle.i18n-string-size' |
@@ -159,7 +159,7 @@
               <label>{{'instrument-management.detail.label.annotations' | translate}} ({{'global.in-german' |
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="de" md-maxlength="2048" md-no-asterisk name="annotationsDe" ng-model="ctrl.instrument.annotations.de" rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!instrumentForm.annotationsDe.$dirty && !instrumentForm.annotationsDe.$touched">{{'instrument-management.edit.hints.annotations.de' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.instrument.annotations.de == null || ctrl.instrument.annotations.de == ''">{{'instrument-management.edit.hints.annotations.de' | translate}}
               </div>
               <div multiple ng-messages="instrumentForm.annotationsDe.$error">
                 <div ng-message="md-maxlength">{{'instrument-management.error.instrument.annotations.i18n-string-size' |
@@ -171,7 +171,7 @@
               <label>{{'instrument-management.detail.label.annotations' | translate}} ({{'global.in-english' |
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="en" md-maxlength="2048" md-no-asterisk name="annotationsEn" ng-model="ctrl.instrument.annotations.en" rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!instrumentForm.annotationsEn.$dirty && !instrumentForm.annotationsEn.$touched">{{'instrument-management.edit.hints.annotations.en' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.instrument.annotations.en == null || ctrl.instrument.annotations.en == ''">{{'instrument-management.edit.hints.annotations.en' | translate}}
               </div>
               <div multiple ng-messages="instrumentForm.annotationsEn.$error">
                 <div ng-message="md-maxlength">{{'instrument-management.error.instrument.annotations.i18n-string-size' |

--- a/src/main/webapp/scripts/surveymanagement/directives/geographic-coverage.html.tmpl
+++ b/src/main/webapp/scripts/surveymanagement/directives/geographic-coverage.html.tmpl
@@ -35,7 +35,7 @@
         <md-input-container flex="grow" ng-class="{'mr10': isScreenGreaterSmall}">
             <label>{{'survey-management.geographic-coverage.label.description.de' | translate}}<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
             <textarea name="descriptionDe" ng-model="geographicCoverage.description.de" rows="4" md-maxlength="512" lang="de"></textarea>
-            <div ng-if="geographicCoverageForm.descriptionDe.$untouched" class="fdz-input-hint">
+            <div ng-if="geographicCoverage.description.de == null || geographicCoverage.description.de == ''" class="fdz-input-hint">
                 {{'survey-management.geographic-coverage.hints.description' | translate}}
             </div>
             <div ng-messages="geographicCoverageForm.descriptionDe.$error">
@@ -45,7 +45,7 @@
         <md-input-container flex="grow">
             <label>{{'survey-management.geographic-coverage.label.description.en' | translate}}<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
             <textarea name="descriptionEn" ng-model="geographicCoverage.description.en" rows="4" md-maxlength="512" lang="en"></textarea>
-            <div ng-if="geographicCoverageForm.descriptionEn.$untouched" class="fdz-input-hint">
+            <div ng-if="geographicCoverage.description.en == null || geographicCoverage.description.en == ''" class="fdz-input-hint">
                 {{'survey-management.geographic-coverage.hints.description' | translate}}
             </div>
             <div ng-messages="geographicCoverageForm.descriptionDe.$error">

--- a/src/main/webapp/scripts/surveymanagement/views/survey-edit-or-create.html.tmpl
+++ b/src/main/webapp/scripts/surveymanagement/views/survey-edit-or-create.html.tmpl
@@ -191,7 +191,7 @@
             <md-input-container flex="50" md-is-error="!surveyForm.grossSampleSize.$valid && (surveyForm.grossSampleSize.$dirty || surveyForm.grossSampleSize.$touched)" class="ms-flex">
               <label>{{'survey-management.detail.label.grossSampleSize' | translate}}</label>
               <input min="{{ ctrl.survey.sampleSize || 0}}" max="2147483647" name="grossSampleSize" ng-model="ctrl.survey.grossSampleSize" step="1" type="number">
-              <div class="fdz-input-hint" ng-if="!surveyForm.grossSampleSize.$dirty && !surveyForm.grossSampleSize.$touched">{{'survey-management.edit.hints.grossSampleSize' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.survey.grossSampleSize == null || ctrl.survey.grossSampleSize == ''">{{'survey-management.edit.hints.grossSampleSize' | translate}}
               </div>
               <div multiple ng-messages="surveyForm.grossSampleSize.$error">
                 <div ng-message="step">{{'survey-management.error.survey.gross-sample-size.invalid-number' |
@@ -230,7 +230,7 @@
             <md-input-container flex="50" md-is-error="!surveyForm.responseRate.$valid && (surveyForm.responseRate.$dirty || surveyForm.responseRate.$touched)" class="ms-flex">
               <label>{{'survey-management.detail.label.responseRate' | translate}} (in %)</label>
               <input max="100" min="0" name="responseRate" ng-model="ctrl.survey.responseRate" step="0.01" type="number">
-              <div class="fdz-input-hint" ng-if="!surveyForm.responseRate.$dirty && !surveyForm.responseRate.$touched">
+              <div class="fdz-input-hint" ng-if="ctrl.survey.responseRate == null || ctrl.survey.responseRate == ''">
                 {{'survey-management.edit.hints.responseRate' | translate}}
               </div>
               <div multiple ng-messages="surveyForm.responseRate.$error">
@@ -253,7 +253,7 @@
               <label>{{'survey-management.detail.label.annotations' | translate}} ({{'global.in-german' |
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="de" md-maxlength="2048" md-no-asterisk name="annotationsDe" ng-model="ctrl.survey.annotations.de" rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!surveyForm.annotationsDe.$dirty && !surveyForm.annotationsDe.$touched">{{'survey-management.edit.hints.annotations.de' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.survey.annotations.de == null || ctrl.survey.annotations.de == ''">{{'survey-management.edit.hints.annotations.de' | translate}}
               </div>
               <div multiple ng-messages="surveyForm.annotationsDe.$error">
                 <div ng-message="fdz-required">{{'survey-management.error.survey.annotations.i18n-string-not-empty' |
@@ -268,7 +268,7 @@
               <label>{{'survey-management.detail.label.annotations' | translate}} ({{'global.in-english' |
                 translate}})<md-icon md-svg-src="assets/images/icons/markdown.svg"></md-icon></label>
               <textarea lang="en" md-maxlength="2048" md-no-asterisk name="annotationsEn" ng-model="ctrl.survey.annotations.en" rows="4"></textarea>
-              <div class="fdz-input-hint" ng-if="!surveyForm.annotationsEn.$dirty && !surveyForm.annotationsEn.$touched">{{'survey-management.edit.hints.annotations.en' | translate}}
+              <div class="fdz-input-hint" ng-if="ctrl.survey.annotations.en == null || ctrl.survey.annotations.en == ''">{{'survey-management.edit.hints.annotations.en' | translate}}
               </div>
               <div multiple ng-messages="surveyForm.annotationsEn.$error">
                 <div ng-message="md-maxlength">{{'survey-management.error.survey.annotations.i18n-string-size' |


### PR DESCRIPTION
Fixed disappearing hints after clicking on a field. Now, the hints disappear as soon as the user adds some input to the field. But they reappear as soon as no text is present in the input field. This behaviour differs a bit when a field is validated (e.g. a mandatory field). Those input fields present an "error"-message as soon as the input is invalid. In this cases the hints stay hidden, because the hint and the error message would basically hold the same information for the user.