### PR TITLE
#3173 Button for reporting publications hides data protection link

### DIFF
--- a/src/main/webapp/scripts/common/footer/footer.html.tmpl
+++ b/src/main/webapp/scripts/common/footer/footer.html.tmpl
@@ -20,6 +20,12 @@
     </div>
     <div class="layout-align-end-center layout-column">
       <div>
+        <a class="fdz-footer__link" ui-sref="disclosure">
+          <span data-translate="global.menu.disclosure">Disclosure</span>
+        </a>
+        <a class="fdz-footer__link" href="{{$ctrl.lang === 'de' ? 'https://www.dzhw.eu/gmbh/datenschutz/datenschutzerklaerung' : 'https://www.dzhw.eu/en/gmbh/datenschutz/datenschutzerklaerung'}}" target="_blank">
+          <span data-translate="global.menu.dataprotection">security</span>
+        </a>
         <a class="fdz-footer__link" href="{{$ctrl.lang === 'de' ? 'https://www.fdz.dzhw.eu/de/datennutzung' : 'https://www.fdz.dzhw.eu/en/data-usage'}}" target="_blank">
           <span data-translate="global.menu.data-access">Data Access</span>
         </a>
@@ -28,12 +34,6 @@
         </a>
         <a class="fdz-footer__link" href="https://metadatamanagement.readthedocs.io/de/stable/" target="_blank">
           <span data-translate="global.menu.documentation">Documentation</span>
-        </a>
-        <a class="fdz-footer__link" ui-sref="disclosure">
-          <span data-translate="global.menu.disclosure">Disclosure</span>
-        </a>
-        <a class="fdz-footer__link" href="{{$ctrl.lang === 'de' ? 'https://www.dzhw.eu/gmbh/datenschutz/datenschutzerklaerung' : 'https://www.dzhw.eu/en/gmbh/datenschutz/datenschutzerklaerung'}}" target="_blank">
-          <span data-translate="global.menu.dataprotection">security</span>
         </a>
       </div>
     </div>

--- a/src/main/webapp/scripts/start/views/start.html.tmpl
+++ b/src/main/webapp/scripts/start/views/start.html.tmpl
@@ -36,6 +36,6 @@
     </div>
   </div>
 </div>
-<div class="fdz-fab-button-container" layout="column" layout-align="center end">
+<div class="fdz-fab-button-container" style="margin-bottom: 25px;" layout="column" layout-align="center end">
   <report-publications-component></report-publications-component>
 </div>


### PR DESCRIPTION
The order of the footer links was changed so data protection and disclosure stand in the front and are always visible. As the start page is the only page where the footer is always visible, I have raised the button for reporting publications a little bit for a cleaner look.