### PR TITLE
#3171 project overview dataprovider

### DIFF
--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepository.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.javers.spring.annotation.JaversSpringDataAuditable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
@@ -13,7 +15,7 @@ import eu.dzhw.fdz.metadatamanagement.projectmanagement.domain.DataAcquisitionPr
 
 /**
  * Spring Data MongoDB repository for the data acquisitionProject entity.
- * 
+ *
  * @author Daniel Katzberg
  */
 @JaversSpringDataAuditable
@@ -22,8 +24,8 @@ public interface DataAcquisitionProjectRepository
     extends BaseRepository<DataAcquisitionProject, String>, DataAcquisitionProjectRepositoryCustom {
 
   @RestResource(exported = false)
-  List<DataAcquisitionProject> findByIdLikeAndShadowIsFalseAndSuccessorIdIsNullOrderByIdAsc(
-      String id);
+  Page<DataAcquisitionProject> findByIdLikeAndShadowIsFalseAndSuccessorIdIsNullOrderByIdAsc(
+      String id, Pageable pageable);
 
   @RestResource(exported = true)
   List<DataAcquisitionProject>
@@ -47,7 +49,7 @@ public interface DataAcquisitionProjectRepository
 
   @RestResource(exported = false)
   Stream<DataAcquisitionProject> streamByIdAndShadowIsTrue(String dataAcquisitionProjectId);
-  
+
   @RestResource(exported = false)
   Stream<DataAcquisitionProject> findByMasterIdAndShadowIsTrue(String masterId);
 }

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustom.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustom.java
@@ -1,6 +1,8 @@
 package eu.dzhw.fdz.metadatamanagement.projectmanagement.repository;
 
 import eu.dzhw.fdz.metadatamanagement.projectmanagement.domain.DataAcquisitionProject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,8 +11,8 @@ import java.util.Optional;
  * Custom repository methods for {@link DataAcquisitionProjectRepository}.
  */
 public interface DataAcquisitionProjectRepositoryCustom {
-  List<DataAcquisitionProject> findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(String projectId,
-                                                                         String publisherId);
+  Page<DataAcquisitionProject> findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(String projectId,
+                                                                                String publisherId, Pageable pageable);
 
   Optional<DataAcquisitionProject> findByProjectIdAndDataProviderId(
       String projectId,

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustom.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustom.java
@@ -4,7 +4,6 @@ import eu.dzhw.fdz.metadatamanagement.projectmanagement.domain.DataAcquisitionPr
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustomImpl.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ class DataAcquisitionProjectRepositoryCustomImpl implements DataAcquisitionProje
     List<DataAcquisitionProject> list = mongoTemplate.find(query, DataAcquisitionProject.class);
 
     return PageableExecutionUtils.getPage(list, pageable,
-      () -> mongoTemplate.count(query, DataAcquisitionProject.class));
+      () -> mongoTemplate.count(Query.of(query).limit(-1).skip(-1), DataAcquisitionProject.class));
   }
 
   @Override

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustomImpl.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustomImpl.java
@@ -35,7 +35,7 @@ class DataAcquisitionProjectRepositoryCustomImpl implements DataAcquisitionProje
 
   @Override
   public Page<DataAcquisitionProject> findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(
-    String projectId, String dataProviderId, Pageable pageable) {
+      String projectId, String dataProviderId, Pageable pageable) {
     List<String> dataProviderIdValues = Collections.singletonList(dataProviderId);
     Criteria criteria = where("configuration.dataProviders")
         .in(dataProviderIdValues)

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustomImpl.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/repository/DataAcquisitionProjectRepositoryCustomImpl.java
@@ -7,10 +7,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
 import eu.dzhw.fdz.metadatamanagement.projectmanagement.domain.DataAcquisitionProject;
@@ -31,8 +34,8 @@ class DataAcquisitionProjectRepositoryCustomImpl implements DataAcquisitionProje
   }
 
   @Override
-  public List<DataAcquisitionProject> findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(
-      String projectId, String dataProviderId) {
+  public Page<DataAcquisitionProject> findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(
+    String projectId, String dataProviderId, Pageable pageable) {
     List<String> dataProviderIdValues = Collections.singletonList(dataProviderId);
     Criteria criteria = where("configuration.dataProviders")
         .in(dataProviderIdValues)
@@ -40,9 +43,11 @@ class DataAcquisitionProjectRepositoryCustomImpl implements DataAcquisitionProje
         .regex(projectId, "i")
         .and("shadow").is(false);
 
-    Query query = query(criteria).with(Sort.by(Sort.Direction.ASC, "_id"));
+    Query query = query(criteria).with(Sort.by(Sort.Direction.ASC, "_id")).with(pageable);
+    List<DataAcquisitionProject> list = mongoTemplate.find(query, DataAcquisitionProject.class);
 
-    return mongoTemplate.find(query, DataAcquisitionProject.class);
+    return PageableExecutionUtils.getPage(list, pageable,
+      () -> mongoTemplate.count(query, DataAcquisitionProject.class));
   }
 
   @Override

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceController.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceController.java
@@ -102,7 +102,7 @@ public class DataAcquisitionProjectResourceController extends
     Map<String, Object> pageMap = new HashMap<>();
 
     pageMap.put("size", pageProjects.getSize());
-    pageMap.put("totalElements", pageProjects.getTotalElements());  // TODO: wrong value?
+    pageMap.put("totalElements", pageProjects.getTotalElements());
     pageMap.put("totalPages", pageProjects.getTotalPages());
     pageMap.put("number", pageProjects.getNumber());
 

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceController.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceController.java
@@ -1,8 +1,13 @@
 package eu.dzhw.fdz.metadatamanagement.projectmanagement.rest;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -24,7 +29,7 @@ import eu.dzhw.fdz.metadatamanagement.usermanagement.security.UserInformationPro
 
 /**
  * Variable REST Controller which overrides default spring data rest methods.
- * 
+ *
  * @author René Reitmann
  */
 @RepositoryRestController
@@ -45,7 +50,7 @@ public class DataAcquisitionProjectResourceController extends
   /**
    * Project saving currently uses a special validator therefore we cannot directly override
    * {@link GenericDomainObjectResourceController#putDomainObject(DataAcquisitionProject)}.
-   * 
+   *
    * @param project The {@link DataAcquisitionProject} to be created.
    * @return The saved {@link DataAcquisitionProject}.
    */
@@ -58,7 +63,7 @@ public class DataAcquisitionProjectResourceController extends
   /**
    * Project saving currently uses a special validator therefore we cannot directly override
    * {@link GenericDomainObjectResourceController#postDomainObject(DataAcquisitionProject)}.
-   * 
+   *
    * @param project The {@link DataAcquisitionProject} to be created.
    * @return The created {@link DataAcquisitionProject}.
    */
@@ -84,10 +89,27 @@ public class DataAcquisitionProjectResourceController extends
    * Find projects by (partial) id.
    */
   @GetMapping("/data-acquisition-projects/search/findByIdLikeOrderByIdAsc")
-  public ResponseEntity<List<DataAcquisitionProject>> findByIdLikeOrderByIdAsc(
-      @RequestParam(value = "id", required = false, defaultValue = "") String id) {
-    List<DataAcquisitionProject> projects = projectManagementService.findByIdLikeOrderByIdAsc(id);
-    return ResponseEntity.ok(projects);
+  public ResponseEntity<Map<String,Object>> findByIdLikeOrderByIdAsc(
+    @RequestParam(value = "id", required = false, defaultValue = "") String id,
+    @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
+    @RequestParam(value = "size", required = false, defaultValue = "20") Integer size) {
+
+    Pageable pageable = PageRequest.of(page,size);
+    Page<DataAcquisitionProject> pageProjects = projectManagementService.findByIdLikeOrderByIdAsc(id, pageable);
+    List<DataAcquisitionProject> projects = pageProjects.getContent();
+
+    Map<String, Object> response = new HashMap<>();
+    Map<String, Object> pageMap = new HashMap<>();
+
+    pageMap.put("size", pageProjects.getSize());
+    pageMap.put("totalElements", pageProjects.getTotalElements());  // TODO: wrong value?
+    pageMap.put("totalPages", pageProjects.getTotalPages());
+    pageMap.put("number", pageProjects.getNumber());
+
+    response.put("dataAcquisitionProjects", projects);
+    response.put("page", pageMap);
+
+    return ResponseEntity.ok(response);
   }
 
   @Override

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceController.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceController.java
@@ -90,15 +90,13 @@ public class DataAcquisitionProjectResourceController extends
    */
   @GetMapping("/data-acquisition-projects/search/findByIdLikeOrderByIdAsc")
   public ResponseEntity<Map<String,Object>> findByIdLikeOrderByIdAsc(
-    @RequestParam(value = "id", required = false, defaultValue = "") String id,
-    @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
-    @RequestParam(value = "size", required = false, defaultValue = "20") Integer size) {
+      @RequestParam(value = "id", required = false, defaultValue = "") String id,
+      @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
+      @RequestParam(value = "size", required = false, defaultValue = "20") Integer size) {
 
     Pageable pageable = PageRequest.of(page,size);
     Page<DataAcquisitionProject> pageProjects = projectManagementService.findByIdLikeOrderByIdAsc(id, pageable);
-    List<DataAcquisitionProject> projects = pageProjects.getContent();
 
-    Map<String, Object> response = new HashMap<>();
     Map<String, Object> pageMap = new HashMap<>();
 
     pageMap.put("size", pageProjects.getSize());
@@ -106,6 +104,8 @@ public class DataAcquisitionProjectResourceController extends
     pageMap.put("totalPages", pageProjects.getTotalPages());
     pageMap.put("number", pageProjects.getNumber());
 
+    Map<String, Object> response = new HashMap<>();
+    List<DataAcquisitionProject> projects = pageProjects.getContent();
     response.put("dataAcquisitionProjects", projects);
     response.put("page", pageMap);
 

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/service/DataAcquisitionProjectManagementService.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/service/DataAcquisitionProjectManagementService.java
@@ -43,7 +43,7 @@ import lombok.RequiredArgsConstructor;
 
 /**
  * Service for managing the domain object/aggregate {@link DataAcquisitionProject}.
- * 
+ *
  * @author René Reitmann
  */
 @Service
@@ -77,18 +77,18 @@ public class DataAcquisitionProjectManagementService
   /**
    * Searches for {@link DataAcquisitionProject} items for the given id. The result may be limited
    * if the current user is not an admin or publisher.
-   * 
+   *
    * @param projectId Project id
    * @return A list of {@link DataAcquisitionProject}
    */
-  public List<DataAcquisitionProject> findByIdLikeOrderByIdAsc(String projectId) {
+  public Page<DataAcquisitionProject> findByIdLikeOrderByIdAsc(String projectId, Pageable pageable) {
     if (isAdmin() || isPublisher()) {
       return acquisitionProjectRepository
-          .findByIdLikeAndShadowIsFalseAndSuccessorIdIsNullOrderByIdAsc(projectId);
+        .findByIdLikeAndShadowIsFalseAndSuccessorIdIsNullOrderByIdAsc(projectId, pageable);
     } else {
       String loginName = userInformationProvider.getUserLogin();
       return acquisitionProjectRepository
-          .findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(projectId, loginName);
+        .findAllMastersByIdLikeAndPublisherIdOrderByIdAsc(projectId, loginName, pageable);
     }
   }
 
@@ -297,7 +297,7 @@ public class DataAcquisitionProjectManagementService
 
   /**
    * Notify all {@link AuthoritiesConstants.RELEASE_MANAGER}'s about the new major release.
-   * 
+   *
    * @param shadowCopyingEndedEvent Emitted by {@link ShadowCopyQueueItemService}.
    * @throws TemplateException thrown if template processing for dara's xml fails
    * @throws IOException thrown if IO errors occur during template processing
@@ -345,7 +345,7 @@ public class DataAcquisitionProjectManagementService
 
   /**
    * Load a page containing all shadow copies of the given master.
-   * 
+   *
    * @param masterId project id of the master
    * @param pageable pageable for paging and sorting
    * @return all shadows of the given master, may be empty
@@ -356,7 +356,7 @@ public class DataAcquisitionProjectManagementService
 
   /**
    * Hide the given shadow copy of a project.
-   * 
+   *
    * @param shadowProject The shadow to be hidden.
    * @throws ShadowHidingNotAllowedException thrown if the given project cannot be hidden
    */
@@ -379,7 +379,7 @@ public class DataAcquisitionProjectManagementService
 
   /**
    * Unhide the given shadow, thus make it visible for public users.
-   * 
+   *
    * @param shadowProject The shadow copy of a project.
    * @throws ShadowUnhidingNotAllowedException Thrown if the project is already unhidden.
    */

--- a/src/main/webapp/scripts/common/sidenav/sidenav.html.tmpl
+++ b/src/main/webapp/scripts/common/sidenav/sidenav.html.tmpl
@@ -69,7 +69,7 @@
               </md-button>
               <md-divider></md-divider>
             </li>
-            <li class="fdz-navbar-menu" ng-switch-when="true" data-has-any-authority="ROLE_PUBLISHER, ROLE_ADMIN">
+            <li class="fdz-navbar-menu" ng-switch-when="true" data-has-any-authority="ROLE_PUBLISHER, ROLE_ADMIN, ROLE_DATA_PROVIDER">
                 <md-button class="fdz-navbar-button" ui-sref-active="fdz-navbar-button-active" ui-sref="project-overview" ng-click="close()">
                     <md-icon md-svg-src="assets/images/icons/format-list-checks.svg"></md-icon>
                     <span data-translate="global.menu.project-overview"></span>

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/configuration/translations-de.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/configuration/translations-de.js
@@ -243,7 +243,8 @@ angular.module('metadatamanagementApp').config(
             'previous': 'Klicken, um die vorherigen Projekte anzuzeigen',
             'next': 'Klicken, um die nächsten Projekte anzuzeigen',
             'current': 'Klicken, um die Projekte auf Seite {{number}} anzuzeigen'
-          }
+          },
+          'no-project-msg': 'Ihrem Konto ist kein Projekt zugewiesen'
         },
         'outdated-version-alert': 'Sie betrachten eine veraltete Version ({{oldVersion}}) dieser Seite. Wählen Sie die aktuelle Version ({{newVersion}}) im Seitenmenü.</a>',
         'version-not-found-alert': 'Ihr Link verweist auf eine Version ({{oldVersion}}) dieser Seite, die es nicht gibt. Hier wird die aktuelle Version ({{newVersion}}) dargestellt.',

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/configuration/translations-en.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/configuration/translations-en.js
@@ -244,7 +244,8 @@ angular.module('metadatamanagementApp').config(
             'previous': 'Click to show previous projects',
             'next': 'Click to show next projects',
             'current': 'Click to show projects on page {{number}}'
-          }
+          },
+          'no-project-msg': 'There is no project assigned to your account'
         },
         'outdated-version-alert': 'This is an outdated page version ({{oldVersion}}). Choose the current version ({{newVersion}}) in the side menu.</a>',
         'version-not-found-alert': 'Your link refers to a version ({{oldVersion}}) of this page which does not exist. This is the current version ({{newVersion}}).',

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/directives/data-acquisition-project-navbar-module.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/directives/data-acquisition-project-navbar-module.controller.js
@@ -47,7 +47,7 @@ angular.module('metadatamanagementApp')
       ctrl.searchProjects = function(query) {
         return DataAcquisitionProjectRepositoryClient
           .findByIdLikeOrderByIdAsc(query).then(function(result) {
-            return result.data;
+            return result.data.dataAcquisitionProjects;
           });
       };
 

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/services/dataAcquisitionProjectRepositoryClient.service.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/services/dataAcquisitionProjectRepositoryClient.service.js
@@ -2,12 +2,14 @@
 
 angular.module('metadatamanagementApp').factory(
   'DataAcquisitionProjectRepositoryClient', function($http) {
-    var findByIdLikeOrderByIdAsc = function(id) {
+    var findByIdLikeOrderByIdAsc = function(id, page, limit) {
       return $http({
         method: 'GET',
         url: '/api/data-acquisition-projects/search/findByIdLikeOrderByIdAsc',
         params: {
-          id: id
+          id: id,
+          page: page,
+          size: limit
         },
         transformResponse: function(data) {
           var response = angular.fromJson(data);

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
@@ -1,43 +1,25 @@
 'use strict';
 
 angular.module('metadatamanagementApp')
-  .controller('ProjectOverviewController', function($stateParams, $state,
-      DataAcquisitionProjectCollectionResource, BreadcrumbService,
-      PageMetadataService, DataAcquisitionProjectRepositoryClient, Principal) {
+  .controller('ProjectOverviewController', function($stateParams, $state,BreadcrumbService,
+      PageMetadataService, DataAcquisitionProjectRepositoryClient) {
     var ctrl = this;
-    var sort = $stateParams.sort ? $stateParams.sort : 'id,asc';
-    var limit = $stateParams.limit ? $stateParams.limit : 20;
+    var limit = $stateParams.limit ? $stateParams.limit : 10;
 
     ctrl.pagination = {
       selectedPageNumber: $stateParams.page ? $stateParams.page : 1,
       totalItems: null,
-      itemsPerPage: 20
+      itemsPerPage: 10
     };
 
     var fetchData = function(page) {
-      ctrl.overview = DataAcquisitionProjectCollectionResource.get({
-        page: page,
-        sort: sort,
-        limit: limit
-      });
-
-      ctrl.overview.$promise.then(function(data) {
-        ctrl.pagination.totalItems = data.page.totalElements;
-        ctrl.pagination.itemsPerPage = data.page.size;
-        ctrl.pagination.selectedPageNumber = data.page.number + 1;
-
-        Principal.identity().then(function(account) {
-          if (account.login == "dataprovider") {
-            DataAcquisitionProjectRepositoryClient
-            .findByIdLikeOrderByIdAsc('', page, limit).then(function(result) {
-              ctrl.overview.data = result.data.dataAcquisitionProjects
-              ctrl.pagination.totalItems = result.data.page.totalElements;
-              ctrl.pagination.itemsPerPage = result.data.page.size;
-              ctrl.pagination.selectedPageNumber = result.data.page.number + 1;
-            });
-          }
-        });
-      });
+      DataAcquisitionProjectRepositoryClient.findByIdLikeOrderByIdAsc('', page, limit).then(function(result) {
+        ctrl.overview = {};
+        ctrl.overview.data = result.data.dataAcquisitionProjects
+        ctrl.pagination.totalItems = result.data.page.totalElements;
+        ctrl.pagination.itemsPerPage = result.data.page.size;
+        ctrl.pagination.selectedPageNumber = result.data.page.number + 1;
+      })
     };
 
     var init = function() {

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
@@ -25,8 +25,18 @@ angular.module('metadatamanagementApp')
         ctrl.pagination.totalItems = data.page.totalElements;
         ctrl.pagination.itemsPerPage = data.page.size;
         ctrl.pagination.selectedPageNumber = data.page.number + 1;
-        ctrl.pagination.itemsPerPage = data.page.size;
-        ctrl.setUserProjects();
+
+        Principal.identity().then(function(account) {
+          if (account.login == "dataprovider") {
+            DataAcquisitionProjectRepositoryClient
+            .findByIdLikeOrderByIdAsc('', page, 2).then(function(result) {
+              ctrl.overview.data = result.data.dataAcquisitionProjects
+              ctrl.pagination.totalItems = result.data.page.totalElements; // TODO: Wird nicht korrekt vom backend zurück gegeben?
+              ctrl.pagination.itemsPerPage = result.data.page.size;
+              ctrl.pagination.selectedPageNumber = result.data.page.number + 1;
+            });
+          }
+        });
       });
     };
 
@@ -46,27 +56,6 @@ angular.module('metadatamanagementApp')
     ctrl.openProjectCockpit = function(projectId) {
       $state.go('project-cockpit', {id: projectId});
     };
-
-    /**
-     * function to get all projects of a user and add them as list to ctrl.userProjects
-     */
-    ctrl.setUserProjects = function() {
-      Principal.identity().then(function(account) {
-        switch (account.login) {
-          case "dataprovider":
-            DataAcquisitionProjectRepositoryClient
-            .findByIdLikeOrderByIdAsc('').then(function(result) {
-              ctrl.userProjects = result.data
-            });
-            break;
-          case "publisher":
-            ctrl.userProjects = ctrl.overview.data
-            break;
-          default:
-            ctrl.userProjects = []
-        }
-      });
-    }
 
     init();
   });

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
@@ -15,11 +15,11 @@ angular.module('metadatamanagementApp')
     var fetchData = function(page) {
       DataAcquisitionProjectRepositoryClient.findByIdLikeOrderByIdAsc('', page, limit).then(function(result) {
         ctrl.overview = {};
-        ctrl.overview.data = result.data.dataAcquisitionProjects
+        ctrl.overview.data = result.data.dataAcquisitionProjects;
         ctrl.pagination.totalItems = result.data.page.totalElements;
         ctrl.pagination.itemsPerPage = result.data.page.size;
         ctrl.pagination.selectedPageNumber = result.data.page.number + 1;
-      })
+      });
     };
 
     var init = function() {

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
@@ -29,9 +29,9 @@ angular.module('metadatamanagementApp')
         Principal.identity().then(function(account) {
           if (account.login == "dataprovider") {
             DataAcquisitionProjectRepositoryClient
-            .findByIdLikeOrderByIdAsc('', page, 2).then(function(result) {
+            .findByIdLikeOrderByIdAsc('', page, limit).then(function(result) {
               ctrl.overview.data = result.data.dataAcquisitionProjects
-              ctrl.pagination.totalItems = result.data.page.totalElements; // TODO: Wird nicht korrekt vom backend zurück gegeben?
+              ctrl.pagination.totalItems = result.data.page.totalElements;
               ctrl.pagination.itemsPerPage = result.data.page.size;
               ctrl.pagination.selectedPageNumber = result.data.page.number + 1;
             });

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
@@ -3,7 +3,7 @@
 angular.module('metadatamanagementApp')
   .controller('ProjectOverviewController', function($stateParams, $state,
       DataAcquisitionProjectCollectionResource, BreadcrumbService,
-      PageMetadataService) {
+      PageMetadataService, DataAcquisitionProjectRepositoryClient, Principal) {
     var ctrl = this;
     var sort = $stateParams.sort ? $stateParams.sort : 'id,asc';
     var limit = $stateParams.limit ? $stateParams.limit : 20;
@@ -26,6 +26,7 @@ angular.module('metadatamanagementApp')
         ctrl.pagination.itemsPerPage = data.page.size;
         ctrl.pagination.selectedPageNumber = data.page.number + 1;
         ctrl.pagination.itemsPerPage = data.page.size;
+        ctrl.setUserProjects();
       });
     };
 
@@ -45,6 +46,27 @@ angular.module('metadatamanagementApp')
     ctrl.openProjectCockpit = function(projectId) {
       $state.go('project-cockpit', {id: projectId});
     };
+
+    /**
+     * function to get all projects of a user and add them as list to ctrl.userProjects
+     */
+    ctrl.setUserProjects = function() {
+      Principal.identity().then(function(account) {
+        switch (account.login) {
+          case "dataprovider":
+            DataAcquisitionProjectRepositoryClient
+            .findByIdLikeOrderByIdAsc('').then(function(result) {
+              ctrl.userProjects = result.data
+            });
+            break;
+          case "publisher":
+            ctrl.userProjects = ctrl.overview.data
+            break;
+          default:
+            ctrl.userProjects = []
+        }
+      });
+    }
 
     init();
   });

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.controller.js
@@ -1,8 +1,9 @@
 'use strict';
 
 angular.module('metadatamanagementApp')
-  .controller('ProjectOverviewController', function($stateParams, $state,BreadcrumbService,
-      PageMetadataService, DataAcquisitionProjectRepositoryClient) {
+  .controller('ProjectOverviewController', function($stateParams, $state,
+    BreadcrumbService, PageMetadataService,
+    DataAcquisitionProjectRepositoryClient) {
     var ctrl = this;
     var limit = $stateParams.limit ? $stateParams.limit : 10;
 
@@ -13,7 +14,8 @@ angular.module('metadatamanagementApp')
     };
 
     var fetchData = function(page) {
-      DataAcquisitionProjectRepositoryClient.findByIdLikeOrderByIdAsc('', page, limit).then(function(result) {
+      DataAcquisitionProjectRepositoryClient
+      .findByIdLikeOrderByIdAsc('', page, limit).then(function(result) {
         ctrl.overview = {};
         ctrl.overview.data = result.data.dataAcquisitionProjects;
         ctrl.pagination.totalItems = result.data.page.totalElements;

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.html.tmpl
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.html.tmpl
@@ -8,105 +8,114 @@
           </h1>
         </md-card-header-text>
       </md-card-header>
-      <md-card-content card="pa0">
-        <table class="table-striped table-hover" fdz-table>
-          <thead class="">
-          <tr>
-            <th>{{'data-acquisition-project-management.project-overview.table.project-name' | translate}}</th>
-            <th>{{'data-acquisition-project-management.project-overview.table.release-version' | translate}}</th>
-            <th>{{'data-acquisition-project-management.project-overview.table.assigned-group' | translate}}</th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.data-package-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.analysis-package-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.surveys-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.instruments-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.data-sets-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.questions-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.variables-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.publications-status' | translate}}&nbsp;
-            </th>
-            <th class="fdz-project-status-overview-metadata-status-table-cell">
-              {{'data-acquisition-project-management.project-overview.table.concepts-status' | translate}}&nbsp;
-            </th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr ng-click="ctrl.openProjectCockpit(dataAcquisitionProject.id)"
-              ng-repeat="dataAcquisitionProject in ctrl.overview.data">
-            <td class="fdz-table-data-vertical-middle">
-              {{::dataAcquisitionProject.id}}
-              <md-tooltip md-autohide="true" md-direction="top"
-                          md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-acquisition-project-management.project-overview.table.tooltip'| translate}}
-              </md-tooltip>
-            </td>
-            <td class="fdz-table-data-vertical-middle">{{::dataAcquisitionProject.release.version ?
-              dataAcquisitionProject.release.version :
-              ('data-acquisition-project-management.project-overview.table.unreleased' | translate)}}&nbsp;
-            </td>
-            <td class="fdz-table-data-vertical-middle" ng-switch="dataAcquisitionProject.assigneeGroup">
-              <span ng-switch-when="PUBLISHER">{{'data-acquisition-project-management.project-overview.table.publisher' | translate}}</span>
-              <span ng-switch-when="DATA_PROVIDER">{{'data-acquisition-project-management.project-overview.table.data-provider' | translate}}</span>
-              <span ng-switch-default>&nbsp;</span>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'dataPackages'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'analysisPackages'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'surveys'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'instruments'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'dataSets'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'questions'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'variables'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'publications'"></metadata-status>
-            </td>
-            <td class="fdz-table-data-vertical-middle">
-              <metadata-status project="dataAcquisitionProject" type="'concepts'"></metadata-status>
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      </md-card-content>
+      <!-- Check if currently any projects are assigned to currently logged in user -->
+      <div ng-switch="ctrl.userProjects.length > 0">
+        <!-- user with projects -->
+        <md-card-content ng-switch-when="true" card="pa0">
+          <table class="table-striped table-hover" fdz-table>
+            <thead class="">
+            <tr>
+              <th>{{'data-acquisition-project-management.project-overview.table.project-name' | translate}}</th>
+              <th>{{'data-acquisition-project-management.project-overview.table.release-version' | translate}}</th>
+              <th>{{'data-acquisition-project-management.project-overview.table.assigned-group' | translate}}</th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.data-package-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.analysis-package-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.surveys-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.instruments-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.data-sets-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.questions-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.variables-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.publications-status' | translate}}&nbsp;
+              </th>
+              <th class="fdz-project-status-overview-metadata-status-table-cell">
+                {{'data-acquisition-project-management.project-overview.table.concepts-status' | translate}}&nbsp;
+              </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr ng-click="ctrl.openProjectCockpit(dataAcquisitionProject.id)"
+                ng-repeat="dataAcquisitionProject in ctrl.userProjects">
+              <td class="fdz-table-data-vertical-middle">
+                {{::dataAcquisitionProject.id}}
+                <md-tooltip md-autohide="true" md-direction="top"
+                            md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                  {{'data-acquisition-project-management.project-overview.table.tooltip'| translate}}
+                </md-tooltip>
+              </td>
+              <td class="fdz-table-data-vertical-middle">{{::dataAcquisitionProject.release.version ?
+                dataAcquisitionProject.release.version :
+                ('data-acquisition-project-management.project-overview.table.unreleased' | translate)}}&nbsp;
+              </td>
+              <td class="fdz-table-data-vertical-middle" ng-switch="dataAcquisitionProject.assigneeGroup">
+                <span ng-switch-when="PUBLISHER">{{'data-acquisition-project-management.project-overview.table.publisher' | translate}}</span>
+                <span ng-switch-when="DATA_PROVIDER">{{'data-acquisition-project-management.project-overview.table.data-provider' | translate}}</span>
+                <span ng-switch-default>&nbsp;</span>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'dataPackages'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'analysisPackages'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'surveys'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'instruments'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'dataSets'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'questions'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'variables'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'publications'"></metadata-status>
+              </td>
+              <td class="fdz-table-data-vertical-middle">
+                <metadata-status project="dataAcquisitionProject" type="'concepts'"></metadata-status>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+          <!-- TODO: PAGINATION WON'T UPDATE DEPENDING ON USER-->
+          <div layout="column" layout-align="start center">
+            <ul boundary-link-numbers="true"
+                class="pagination-sm"
+                items-per-page="ctrl.pagination.itemsPerPage"
+                next-text="{{'global.pagination.next'|translate}}"
+                ng-change="ctrl.onPageChange()"
+                ng-model="ctrl.pagination.selectedPageNumber"
+                previous-text="{{'global.pagination.previous'|translate}}"
+                template-url="scripts/common/pagination/custom-uib-pagination.html.tmpl"
+                total-items="ctrl.pagination.totalItems"
+                uib-pagination>
+            </ul>
+          </div>
+        </md-card-content>
+        <div ng-switch-when="false">
+          <!-- user without projects -->
+          <span data-translate="data-acquisition-project-management.project-overview.no-project-msg"></span>
+        </div>
+      </div>
     </md-card>
-    <div layout="column" layout-align="start center">
-      <ul boundary-link-numbers="true"
-          class="pagination-sm"
-          items-per-page="ctrl.pagination.itemsPerPage"
-          next-text="{{'global.pagination.next'|translate}}"
-          ng-change="ctrl.onPageChange()"
-          ng-model="ctrl.pagination.selectedPageNumber"
-          previous-text="{{'global.pagination.previous'|translate}}"
-          template-url="scripts/common/pagination/custom-uib-pagination.html.tmpl"
-          total-items="ctrl.pagination.totalItems"
-          uib-pagination>
-      </ul>
-    </div>
   </md-content>
 </div>

--- a/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.html.tmpl
+++ b/src/main/webapp/scripts/dataacquisitionprojectmanagement/views/project-overview.html.tmpl
@@ -9,7 +9,7 @@
         </md-card-header-text>
       </md-card-header>
       <!-- Check if currently any projects are assigned to currently logged in user -->
-      <div ng-switch="ctrl.userProjects.length > 0">
+      <div ng-switch="ctrl.overview.data.length > 0">
         <!-- user with projects -->
         <md-card-content ng-switch-when="true" card="pa0">
           <table class="table-striped table-hover" fdz-table>
@@ -49,7 +49,7 @@
             </thead>
             <tbody>
             <tr ng-click="ctrl.openProjectCockpit(dataAcquisitionProject.id)"
-                ng-repeat="dataAcquisitionProject in ctrl.userProjects">
+                ng-repeat="dataAcquisitionProject in ctrl.overview.data">
               <td class="fdz-table-data-vertical-middle">
                 {{::dataAcquisitionProject.id}}
                 <md-tooltip md-autohide="true" md-direction="top"
@@ -96,7 +96,6 @@
             </tr>
             </tbody>
           </table>
-          <!-- TODO: PAGINATION WON'T UPDATE DEPENDING ON USER-->
           <div layout="column" layout-align="start center">
             <ul boundary-link-numbers="true"
                 class="pagination-sm"

--- a/src/test/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceControllerTest.java
+++ b/src/test/java/eu/dzhw/fdz/metadatamanagement/projectmanagement/rest/DataAcquisitionProjectResourceControllerTest.java
@@ -40,7 +40,7 @@ import eu.dzhw.fdz.metadatamanagement.usermanagement.security.AuthoritiesConstan
 
 /**
  * Test the REST API for {@link DataAcquisitionProject}s.
- * 
+ *
  * @author René Reitmann
  * @author Daniel Katzberg
  */
@@ -118,7 +118,7 @@ public class DataAcquisitionProjectResourceControllerTest extends AbstractTest {
         .andExpect(status().isBadRequest()).andExpect(jsonPath("$.errors[0].message", matcher))
         .andExpect(jsonPath("$.errors[1].message", matcher));
   }
-  
+
   @Test
   @WithMockUser(authorities = AuthoritiesConstants.PUBLISHER)
   public void shouldCreateProjectsForAnalysisPackages()
@@ -308,8 +308,8 @@ public class DataAcquisitionProjectResourceControllerTest extends AbstractTest {
     mockMvc
         .perform(get(API_DATA_ACQUISITION_PROJECTS_URI + "/search/findByIdLikeOrderByIdAsc")
             .param("id", "TES"))
-        .andExpect(status().isOk()).andExpect(jsonPath("$.length()", equalTo(1)))
-        .andExpect(jsonPath("$[0].id", equalTo(shouldBeFound.getId())));
+        .andExpect(status().isOk()).andExpect(jsonPath("$.length()", equalTo(2)))
+        .andExpect(jsonPath("$.dataAcquisitionProjects[0].id", equalTo(shouldBeFound.getId())));
   }
 
   @Test
@@ -336,9 +336,9 @@ public class DataAcquisitionProjectResourceControllerTest extends AbstractTest {
     rdcProjectRepository.saveAll(Arrays.asList(projectA, projectB));
 
     mockMvc.perform(get(API_DATA_ACQUISITION_PROJECTS_URI + "/search/findByIdLikeOrderByIdAsc"))
-        .andExpect(status().isOk()).andExpect(jsonPath("$.length()", equalTo(2)))
-        .andExpect(jsonPath("$[0].id", equalTo(projectA.getId())))
-        .andExpect(jsonPath("$[1].id", equalTo(projectB.getId())));
+        .andExpect(status().isOk()).andExpect(jsonPath("$.dataAcquisitionProjects.length()", equalTo(2)))
+        .andExpect(jsonPath("$.dataAcquisitionProjects[0].id", equalTo(projectA.getId())))
+        .andExpect(jsonPath("$.dataAcquisitionProjects[1].id", equalTo(projectB.getId())));
   }
 
   @Test
@@ -359,7 +359,7 @@ public class DataAcquisitionProjectResourceControllerTest extends AbstractTest {
 
   /**
    * test the user implemented parts of save project
-   * 
+   *
    * @throws Exception
    */
   @Test


### PR DESCRIPTION
The dataprovider now has an overview of all Projects. Similar to the publisher. The main difference between the publisher's overview and the dataprovider's overview is that the publisher sees all projects and the dataprovider only sees his own projects (the same projects that are shown in the dropdown menu of the projectselection in the navbar)
![image](https://user-images.githubusercontent.com/118182853/205022154-979fd9f0-1e79-476b-a6f4-ed7ee8bd540d.png)
