### PR TITLE
#3198 allow display of multiple dialogs

### DIFF
--- a/src/main/webapp/scripts/common/people/edit-people.controller.js
+++ b/src/main/webapp/scripts/common/people/edit-people.controller.js
@@ -95,6 +95,7 @@ angular.module('metadatamanagementApp')
               'choose-orcid.html.tmpl',
             clickOutsideToClose: false,
             fullscreen: true,
+            multiple: true,
             locals: {
               firstName: firstName,
               lastName: lastName,


### PR DESCRIPTION
When searching for ORCIDs in the add attachments dialog, another dialog opens. By allowing multiple dialogs to be displayed, the first dialog does not crash.