### PR TITLE
#3257: added new VerbundFDB-field to datapackage detail- and editpage

### DIFF
--- a/mdm-frontend/src/app/legacy/datapackagemanagement/configuration/translations-de.js
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/configuration/translations-de.js
@@ -22,6 +22,7 @@ angular.module('metadatamanagementApp').config([
             'version': 'Version',
             'surveyDesign': 'Erhebungsdesign',
             'annotations': 'Anmerkungen',
+            'transmission-via-VerbundFdb': 'Datenmeldung über den VerbundFDB',
             'remarksUserService': 'Bemerkungen für den User Service',
             'externalDataPackage': 'DZHW-externes Datenpaket',
             'wave': 'Wellen',

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/configuration/translations-en.js
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/configuration/translations-en.js
@@ -22,6 +22,7 @@ angular.module('metadatamanagementApp').config([
             'version': 'Version',
             'surveyDesign': 'Survey Design',
             'annotations': 'Annotations',
+            'transmission-via-VerbundFdb': 'Data transmission via the VerbundFDB',
             'remarksUserService': 'Remarks for the User Service',
             'externalDataPackage': 'DZHW external data package',
             'wave': 'Waves',

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/templates/common-details.html.tmpl
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/templates/common-details.html.tmpl
@@ -113,6 +113,11 @@
             markdown-to-html="$ctrl.options.dataPackage.annotations | displayI18nString"
             ></p>
         </md-list-item>
+        <md-list-item ng-if="$ctrl.options.dataPackage.transmissionViaVerbundFdb && $ctrl.options.isPublisher()">
+          <h5>{{'data-package-management.detail.label.transmission-via-VerbundFdb' | translate }}:</h5>
+          <input type="checkbox" ng-model="$ctrl.options.dataPackage.transmissionViaVerbundFdb"
+           ng-true-value="true" ng-false-value="false" ng-disabled=true>
+        </md-list-item>
         <md-list-item ng-if="$ctrl.options.dataPackage.externalDataPackage && $ctrl.options.isPublisher()">
             <h5>{{'data-package-management.detail.label.externalDataPackage' | translate }}:</h5>
             <input type="checkbox" ng-model="$ctrl.options.dataPackage.externalDataPackage"

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-edit-or-create.html.tmpl
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-edit-or-create.html.tmpl
@@ -153,7 +153,12 @@
                 ng-model="ctrl.dataPackage.remarksUserService" ng-trim="true">  
             </md-input-container>
           </div>
-          <div layout="column" layout-gt-sm="row" style="margin-bottom: 18pt;">
+          <div layout="column" layout-gt-sm="row">
+            <md-input-container flex="50" class="mv8" ng-if="ctrl.isPublisher()">
+              <md-checkbox ng-model="ctrl.dataPackage.transmissionViaVerbundFdb" name="dataPackage" class="mb0">
+                {{'data-package-management.detail.label.transmission-via-VerbundFdb' | translate}}
+              </md-checkbox>
+            </md-input-container>
             <md-input-container flex="50" class="mv8" ng-if="ctrl.isPublisher()">
                 <md-checkbox ng-model="ctrl.dataPackage.externalDataPackage" name="dataPackage" class="mb0">
                   {{'data-package-management.detail.label.externalDataPackage' | translate}}

--- a/mdm-frontend/src/app/legacy/searchmanagement/configuration/translations-de.js
+++ b/mdm-frontend/src/app/legacy/searchmanagement/configuration/translations-de.js
@@ -181,6 +181,7 @@ angular.module('metadatamanagementApp').config([
           'sponsor-en': 'Sponsor',
           'survey-method-de': 'Erhebungsmethode',
           'survey-method-en': 'Erhebungsmethode',
+          'transmissionViaVerbundFdb': 'Datenmeldung über den VerbundFDB',
           'externalDataPackage': 'DZHW-externes Datenpaket',
           'floating-label': {
             'survey': 'Nach welcher Erhebung wollen Sie filtern?',

--- a/mdm-frontend/src/app/legacy/searchmanagement/configuration/translations-en.js
+++ b/mdm-frontend/src/app/legacy/searchmanagement/configuration/translations-en.js
@@ -182,6 +182,7 @@ angular.module('metadatamanagementApp').config([
           'sponsor-en': 'Sponsor',
           'survey-method-de': 'Survey Method',
           'survey-method-en': 'Survey Method',
+          'transmissionViaVerbundFdb': 'Data transmission via the VerbundFDB',
           'externalDataPackage': 'DZHW external data package',
           'floating-label': {
             'survey': 'By which survey do you want to filter?',

--- a/mdm-frontend/src/app/legacy/searchmanagement/directives/search-filter-panel.controller.js
+++ b/mdm-frontend/src/app/legacy/searchmanagement/directives/search-filter-panel.controller.js
@@ -16,6 +16,7 @@ angular.module('metadatamanagementApp')
       var elasticSearchTypeChanged = false;
       var searchParamsFilterChanged = false;
       $scope.filtersCollapsed = false;
+      $scope.transmissionViaVerbundFdb = false;
       $scope.externalDataPackage = false;
 
       var createDisplayAvailableFilterList = function(availableFilters) {
@@ -42,6 +43,7 @@ angular.module('metadatamanagementApp')
         // show filter externalDataPackage only to users with role publisher
         if (!Principal.isPublisher()) {
           displayAvailableFilters = displayAvailableFilters.filter(item => item !== "externalDataPackage");
+          displayAvailableFilters = displayAvailableFilters.filter(item => item !== "transmissionViaVerbundFdb");
         }
         
         return displayAvailableFilters;
@@ -103,6 +105,7 @@ angular.module('metadatamanagementApp')
             $scope.availableHiddenFilters, unselectedFilters);
           $scope.filterChangedCallback();
         }
+        $scope.transmissionViaVerbundFDB = $scope.currentSearchParams.filter['transmissionViaVerbundFdb'];
         $scope.externalDataPackage = $scope.currentSearchParams.filter['externalDataPackage'];
       });
 
@@ -168,6 +171,19 @@ angular.module('metadatamanagementApp')
       $scope.isPublisher = function() {
         return Principal.isPublisher();
       };
+
+      /**
+       * Function to set the value of transmissionViaVerbundFDB in the filter of currentSearchParams.
+       */
+       $scope.onTransmissionViaVerbundFdbClick = function() {
+        $scope.transmissionViaVerbundFdb = !$scope.transmissionViaVerbundFdb
+        if ($scope.transmissionViaVerbundFdb) {
+          $scope.currentSearchParams.filter['transmissionViaVerbundFdb'] = true;
+        } else {
+          $scope.currentSearchParams.filter['transmissionViaVerbundFdb'] = false;
+        }
+        $scope.filterChangedCallback();
+      }
 
       /**
        * Function to set the value of externalDataPackage in the filter of currentSearchParams.

--- a/mdm-frontend/src/app/legacy/searchmanagement/directives/search-filter-panel.html.tmpl
+++ b/mdm-frontend/src/app/legacy/searchmanagement/directives/search-filter-panel.html.tmpl
@@ -51,7 +51,10 @@
         <concept-search-filter ng-if="selectedFilters.indexOf('concept') >= 0" current-language="currentLanguage" current-search-params="currentSearchParams" concept-changed-callback="onOneFilterChanged" bowser="bowser"></concept-search-filter>
         <sponsor-search-filter ng-if="selectedFilters.indexOf('sponsor-de') >= 0 || selectedFilters.indexOf('sponsor-en') >= 0" current-language="currentLanguage" current-search-params="currentSearchParams" sponsor-changed-callback="onOneFilterChanged()" bowser="bowser"></sponsor-search-filter>
         <survey-method-search-filter ng-if="selectedFilters.indexOf('survey-method-de') >= 0 || selectedFilters.indexOf('survey-method-en') >= 0" current-language="currentLanguage" current-search-params="currentSearchParams" survey-method-changed-callback="onOneFilterChanged()" bowser="bowser"></survey-method-search-filter>
-        <md-checkbox ng-if="selectedFilters.indexOf('externalDataPackage') >= 0 && isPublisher()" ng-model="externalDataPackage" ng-change="onExternalDataPackageClick()" name="dataPackage" class="mb0">
+        <md-checkbox layout="column" layout-gt-sm="row" ng-if="selectedFilters.indexOf('transmissionViaVerbundFdb') >= 0 && isPublisher()" ng-model="transmissionViaVerbundFdb" ng-change="onTransmissionViaVerbundFdbClick()" name="dataPackage" class="mb0">
+            {{'search-management.filter.transmissionViaVerbundFdb' | translate}}
+        </md-checkbox>
+        <md-checkbox layout="column" layout-gt-sm="row" ng-if="selectedFilters.indexOf('externalDataPackage') >= 0 && isPublisher()" ng-model="externalDataPackage" ng-change="onExternalDataPackageClick()" name="dataPackage" class="mb0">
             {{'search-management.filter.externalDataPackage' | translate}}
         </md-checkbox>
         <input type="submit" ng-hide="true">

--- a/mdm-frontend/src/app/legacy/searchmanagement/services/searchHelper.service.js
+++ b/mdm-frontend/src/app/legacy/searchmanagement/services/searchHelper.service.js
@@ -150,6 +150,7 @@ angular.module('metadatamanagementApp').factory('SearchHelperService', ['CleanJS
         'survey-method-de': 'surveys.surveyMethod.de',
         'survey-method-en': 'surveys.surveyMethod.en',
         'concept': 'concepts.id',
+        'transmissionViaVerbundFdb': 'transmissionViaVerbundFdb',
         'externalDataPackage': 'externalDataPackage'
       },
       'analysis_packages': {

--- a/src/main/java/eu/dzhw/fdz/metadatamanagement/datapackagemanagement/domain/DataPackage.java
+++ b/src/main/java/eu/dzhw/fdz/metadatamanagement/datapackagemanagement/domain/DataPackage.java
@@ -215,6 +215,12 @@ public class DataPackage extends AbstractShadowableRdcDomainObject
   private String remarksUserService;
 
   /**
+   * Shows if a dataPackage was transmitted via VerbundFDB.
+   */
+  @Indexed
+  private Boolean transmissionViaVerbundFdb = false;
+
+  /**
    * Shows if a data package is external.
    */
   @Indexed

--- a/src/main/resources/elasticsearch/data_packages/mapping.json
+++ b/src/main/resources/elasticsearch/data_packages/mapping.json
@@ -1057,6 +1057,9 @@
 				}
 			}
 		},
+    "transmissionViaVerbundFdb": {
+      "type": "boolean"
+    },
     "externalDataPackage": {
       "type": "boolean"
     }


### PR DESCRIPTION
**short note**: There was another pull request (https://github.com/dzhw/metadatamanagement/pull/3287) that got a little mixed up after a rebase. I therefore forked a new feature branch from the `dev-2023-2-1` branch and created a new pull request (this one) for it.

The old pull request was closed.