### PR TITLE
Fixing ELSST tags search requests [TEST]

### DIFF
--- a/mdm-frontend/src/app/legacy/analysispackagemanagement/views/analysis-package-detail.html.tmpl
+++ b/mdm-frontend/src/app/legacy/analysispackagemanagement/views/analysis-package-detail.html.tmpl
@@ -14,7 +14,15 @@
           <div class="fdz-tag-link-container" ng-if="ctrl.analysisPackageTags.length > 0">
             <h5>{{'analysis-package-management.detail.label.tags' | translate}}: </h5>
             <a ng-repeat="tag in ctrl.analysisPackageTags"
-               ng-if="ctrl.isAuthenticated()"
+               ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+               ui-sref="searchReleased({type: 'analysis_packages', 'tags': tag})">
+              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                {{'analysis-package-management.detail.tag-tooltip' | translate}}
+              </md-tooltip>
+            </a>
+            <a ng-repeat="tag in ctrl.analysisPackageTags"
+               ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
                ui-sref="search({type: 'analysis_packages', 'query': tag})">
               <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
               <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
@@ -45,16 +53,24 @@
               </div>
               <div>
                 <a ng-repeat="tagElsst in ctrl.analysisPackageTagsElsst"
-                  ng-if="ctrl.isAuthenticated()"
-                  ui-sref="search({type: 'analysis_packages', 'query': tagElsst.prefLabel})">
+                  ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                  ui-sref="searchReleased({type: 'analysis_packages', 'tagsElsst': tagElsst.prefLabel})">
                   <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
                   <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'analysis-package-management.detail.tagElsst-tooltip' | translate}}
                   </md-tooltip>
                 </a>
+                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
+                    ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                    ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})">
+                    <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                  </md-tooltip>
+                </a>
                 <a ng-repeat="tagElsst in ctrl.analysisPackageTagsElsst"
                   ng-if="!ctrl.isAuthenticated()"
-                  ui-sref="search({type: 'analysis_packages', 'tags': tagElsst.prefLabel})">
+                  ui-sref="search({type: 'analysis_packages', 'tagsElsst': tagElsst.prefLabel})">
                   <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
                   <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'analysis-package-management.detail.tagElsst-tooltip' | translate}}

--- a/mdm-frontend/src/app/legacy/conceptmanagement/views/concept-detail.html.tmpl
+++ b/mdm-frontend/src/app/legacy/conceptmanagement/views/concept-detail.html.tmpl
@@ -12,14 +12,25 @@
           </div>
           <div class="fdz-tag-link-container" ng-if="ctrl.conceptTags.length > 0">
             <h5>{{'data-package-management.detail.label.tags' | translate}}: </h5>
+            <!-- When in order view search for data packages as concepts cannot be searched from that view -->
             <a ng-repeat="tag in ctrl.conceptTags"
-               ng-if="ctrl.isAuthenticated()"
+               ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+               ui-sref="searchReleased({type: 'data_packages', 'query': tag})">
+              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                {{'data-package-management.detail.tag-tooltip' | translate}}
+              </md-tooltip>
+            </a>
+            <!-- When in provider view search for concepts -->
+            <a ng-repeat="tag in ctrl.conceptTags"
+               ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
                ui-sref="search({type: 'concepts', 'query': tag})">
               <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
               <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                 {{'data-package-management.detail.tag-tooltip' | translate}}
               </md-tooltip>
             </a>
+            <!-- When in unauthenticated order view search for data packages as concepts cannot be searched from that view -->
             <a ng-repeat="tag in ctrl.conceptTags"
                ng-if="!ctrl.isAuthenticated()"
                ui-sref="search({type: 'data_packages', 'query': tag})" rel="nofollow">
@@ -43,17 +54,28 @@
                 <h5>: </h5>
               </div>
               <div>
+                <!-- When in order view search for data packages as concepts cannot be searched from that view -->
                 <a ng-repeat="tagElsst in ctrl.conceptTagsElsst"
-                  ng-if="ctrl.isAuthenticated()"
-                  ui-sref="search({type: 'concepts', 'query': tagElsst.prefLabel})">
+                  ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                  ui-sref="searchReleased({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
                   <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
                   <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'data-package-management.detail.tagElsst-tooltip' | translate}}
                   </md-tooltip>
                 </a>
+                <!-- When in provider view search for concepts -->
+                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
+                    ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                    ui-sref="search({type: 'concepts', 'query': tagElsst.prefLabel})">
+                    <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                  </md-tooltip>
+                </a>
+                <!-- When in unauthenticated order view search for data packages as concepts cannot be searched from that view -->
                 <a ng-repeat="tagElsst in ctrl.conceptTagsElsst"
                   ng-if="!ctrl.isAuthenticated()"
-                  ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})" rel="nofollow">
+                  ui-sref="search({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})" rel="nofollow">
                   <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
                   <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'data-package-management.detail.tagElsst-tooltip' | translate}}
@@ -62,25 +84,6 @@
               </div>
             </div>
           </div>
-          <!-- <div class="fdz-tag-link-container" ng-if="ctrl.conceptTagsElsst.length > 0">
-            <h5>{{'data-package-management.detail.label.tagsElsst' | translate}}: </h5>
-            <a ng-repeat="tagElsst in ctrl.conceptTagsElsst"
-               ng-if="ctrl.isAuthenticated()"
-               ui-sref="search({type: 'concepts', 'query': tagElsst.prefLabel})">
-              <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <a ng-repeat="tagElsst in ctrl.conceptTagsElsst"
-               ng-if="!ctrl.isAuthenticated()"
-               ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})" rel="nofollow">
-              <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-          </div> -->
         </div>
         <md-divider></md-divider>
         <fdz-detail

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.html.tmpl
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.html.tmpl
@@ -14,7 +14,15 @@
           <div class="fdz-tag-link-container" ng-if="ctrl.dataPackageTags.length > 0">
             <h5>{{'data-package-management.detail.label.tags' | translate}}: </h5>
             <a ng-repeat="tag in ctrl.dataPackageTags"
-               ng-if="ctrl.isAuthenticated()"
+               ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+               ui-sref="searchReleased({type: 'data_packages', 'tags': tag})">
+              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                {{'data-package-management.detail.tag-tooltip' | translate}}
+              </md-tooltip>
+            </a>
+            <a ng-repeat="tag in ctrl.dataPackageTags"
+               ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
                ui-sref="search({type: 'data_packages', 'query': tag})">
               <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
               <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
@@ -45,7 +53,15 @@
               </div>
               <div>
                 <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
-                    ng-if="ctrl.isAuthenticated()"
+                    ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                    ui-sref="searchReleased({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
+                    <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                  </md-tooltip>
+                </a>
+                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
+                    ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
                     ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})">
                     <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
                   <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
@@ -54,7 +70,7 @@
                 </a>
                 <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
                     ng-if="!ctrl.isAuthenticated()"
-                    ui-sref="search({type: 'data_packages', 'tags': tagElsst.prefLabel})">
+                    ui-sref="search({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
                   <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
                   <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'data-package-management.detail.tagElsst-tooltip' | translate}}


### PR DESCRIPTION
When clicking on ELSST tags (and normal tags) on the detail page of datapackages, analysispackages and concepts the search resulted in an "no results" message. The search requests where fixed to take the current view into account and perform the search directly on the tags instead of using the general query field.