### PR TITLE
Fix order sidebar for DOI links to hidden data packages

### DIFF
--- a/mdm-frontend/src/app/legacy/datapackagemanagement/configuration/data-package.js
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/configuration/data-package.js
@@ -9,7 +9,7 @@ function($stateProvider, $urlRouterProvider) {
         SimpleMessageToastService, id, version, excludes) {
       var loadLatestShadowCopyFallback = function() {
         return DataPackageSearchService.findShadowByIdAndVersion(id, null,
-          excludes).promise.then(function(result) {
+          excludes, true).promise.then(function(result) {
             if (result) {
               return result;
             } else {
@@ -21,7 +21,7 @@ function($stateProvider, $urlRouterProvider) {
       };
 
       return DataPackageSearchService.findShadowByIdAndVersion(id, version,
-        excludes).promise.then(function(result) {
+        excludes, true).promise.then(function(result) {
           if (result) {
             return result;
           } else {

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/services/dataPackageSearch.service.js
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/services/dataPackageSearch.service.js
@@ -73,10 +73,12 @@ angular.module('metadatamanagementApp').factory('DataPackageSearchService', [
       return deferred;
     };
 
-    var findShadowByIdAndVersion = function(id, version, excludes) {
+    var findShadowByIdAndVersion = function(id, version, excludes,
+        includeHidden) {
       var query = {};
       _.extend(query, createQueryObject(),
-        SearchHelperService.createShadowByIdAndVersionQuery(id, version));
+        SearchHelperService.createShadowByIdAndVersionQuery(id, version,
+          includeHidden));
       if (excludes) {
         query.body._source = {
           'excludes': excludes
@@ -728,4 +730,3 @@ angular.module('metadatamanagementApp').factory('DataPackageSearchService', [
       findTags: findTags
     };
   }]);
-

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.controller.js
@@ -1,3 +1,4 @@
+/* global _ */
 'use strict';
 
 /**
@@ -181,14 +182,16 @@ angular.module('metadatamanagementApp')
           MessageBus.set('onDataPackageChange',
             {
               masterId: result.masterId,
-              projectId: result.dataAcquisitionProjectId
+              projectId: result.dataAcquisitionProjectId,
+              version: _.get(result, 'release.version')
             });
           MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
         } else {
           MessageBus.set('onDataPackageChange',
           {
             masterId: result.masterId,
-            projectId: result.dataAcquisitionProjectId
+            projectId: result.dataAcquisitionProjectId,
+            version: _.get(result, 'release.version')
           });
           MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
         }
@@ -343,4 +346,3 @@ angular.module('metadatamanagementApp')
         });
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/datasetmanagement/views/dataSet-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/datasetmanagement/views/dataSet-detail.controller.js
@@ -79,12 +79,14 @@ angular.module('metadatamanagementApp')
             'instruments', 'relatedPublications','concepts']);
         OutdatedVersionNotifier.checkVersionAndNotify(result, fetchFn);
 
-        if (!Principal.isAuthenticated()) {
+        if (!Principal.isAuthenticated() || !Principal.isProviderActive()) {
           MessageBus.set('onDataPackageChange',
             {
               masterId: result.dataPackage.masterId,
-              projectId: result.dataAcquisitionProjectId
+              projectId: result.dataAcquisitionProjectId,
+              version: _.get(result, 'release.version')
             });
+          MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
         }
 
         var currentLanguage = LanguageService.getCurrentInstantly();
@@ -169,4 +171,3 @@ angular.module('metadatamanagementApp')
         $mdSidenav('SideNavBar').toggle();
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/instrumentmanagement/views/instrument-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/instrumentmanagement/views/instrument-detail.controller.js
@@ -97,12 +97,14 @@ angular.module('metadatamanagementApp')
         });
         var currenLanguage = LanguageService.getCurrentInstantly();
         var secondLanguage = currenLanguage === 'de' ? 'en' : 'de';
-        if (!Principal.isAuthenticated()) {
+        if (!Principal.isAuthenticated() || !Principal.isProviderActive()) {
           MessageBus.set('onDataPackageChange',
             {
               masterId: result.dataPackage.masterId,
-              projectId: result.dataAcquisitionProjectId
+              projectId: result.dataAcquisitionProjectId,
+              version: _.get(result, 'release.version')
             });
+          MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
         }
         PageMetadataService.setPageTitle('instrument-management.' +
           'detail.page-title', {
@@ -210,4 +212,3 @@ angular.module('metadatamanagementApp')
       // (clicking the button in the common details subview)
       $scope.$on("open-instrument-citation-dialog", () => openInstrumentAttachmentCitationDialog());
     }]);
-

--- a/mdm-frontend/src/app/legacy/ordermanagement/components/data-package-configurator.controller.js
+++ b/mdm-frontend/src/app/legacy/ordermanagement/components/data-package-configurator.controller.js
@@ -180,7 +180,8 @@
           $rootScope.$broadcast('stop-ignoring-404');
         });
       } else {
-        DataPackageSearchService.findShadowByIdAndVersion(id, version, excludes)
+        DataPackageSearchService.findShadowByIdAndVersion(id, version,
+          excludes, true)
         .promise.then(function(data) {
           $ctrl.dataPackage = data;
           $rootScope.selectedDataPackage = data;
@@ -339,7 +340,7 @@
         if (data) {
           var versionFromUrl = $location.search().version;
           $ctrl.dataPackageIdVersion.masterId = data.masterId;
-          $ctrl.dataPackageIdVersion.version = versionFromUrl;
+          $ctrl.dataPackageIdVersion.version = versionFromUrl || data.version;
           $ctrl.dataPackageIdVersion.projectId = data.projectId;
           init();
         }

--- a/mdm-frontend/src/app/legacy/questionmanagement/views/question-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/questionmanagement/views/question-detail.controller.js
@@ -68,11 +68,14 @@ angular.module('metadatamanagementApp')
           title.instrumentDescription = result.instrument.
           description[$rootScope.currentLanguage];
         }
-        if (!Principal.isAuthenticated()) {
+        if (!Principal.isAuthenticated() || !Principal.isProviderActive()) {
           MessageBus.set('onDataPackageChange',
             {
-              masterId: result.dataPackage.masterId
+              masterId: result.dataPackage.masterId,
+              projectId: result.dataAcquisitionProjectId,
+              version: _.get(result, 'release.version')
             });
+          MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
         }
         ctrl.onlyQualitativeData = ContainsOnlyQualitativeDataChecker
           .check(result);
@@ -193,4 +196,3 @@ angular.module('metadatamanagementApp')
         $mdSidenav('SideNavBar').toggle();
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/searchmanagement/services/searchHelper.service.js
+++ b/mdm-frontend/src/app/legacy/searchmanagement/services/searchHelper.service.js
@@ -756,9 +756,11 @@ angular.module('metadatamanagementApp')
      * Creates a query to search an object by id and version.
      * @param {*} id the id to search by
      * @param {*} version the version to search by
+     * @param {boolean} includeHidden true if hidden objects may be returned
      * @returns the query object
      */
-    var createShadowByIdAndVersionQuery = function(id, version) {
+    var createShadowByIdAndVersionQuery = function(id, version,
+        includeHidden) {
       var query = {
         'body': {
           'query': {
@@ -785,7 +787,7 @@ angular.module('metadatamanagementApp')
         }
       };
 
-      if (!Principal.loginName()) {
+      if (!includeHidden && !Principal.loginName()) {
         query.body.query.constant_score.filter.bool.must.push({
           'term': {
             'hidden': false
@@ -1030,4 +1032,3 @@ angular.module('metadatamanagementApp')
       addNewFilters: addNewFilters
     };
   }]);
-

--- a/mdm-frontend/src/app/legacy/surveymanagement/views/survey-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/surveymanagement/views/survey-detail.controller.js
@@ -87,12 +87,14 @@ angular.module('metadatamanagementApp')
           'survey-management.detail.description', {
             population: survey.population.description[currenLanguage]
           });
-        if (!Principal.isAuthenticated()) {
+        if (!Principal.isAuthenticated() || !Principal.isProviderActive()) {
           MessageBus.set('onDataPackageChange',
             {
               masterId: survey.dataPackage.masterId,
-              projectId: survey.dataAcquisitionProjectId
+              projectId: survey.dataAcquisitionProjectId,
+              version: _.get(survey, 'release.version')
             });
+          MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
         }
         BreadcrumbService.updateToolbarHeader({
           'stateName': $state.current.name,
@@ -176,4 +178,3 @@ angular.module('metadatamanagementApp')
         $mdSidenav('SideNavBar').toggle();
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/variablemanagement/views/variable-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/variablemanagement/views/variable-detail.controller.js
@@ -124,12 +124,14 @@ angular.module('metadatamanagementApp')
           }
         );
       }
-      if (!Principal.isAuthenticated()) {
+      if (!Principal.isAuthenticated() || !Principal.isProviderActive()) {
         MessageBus.set('onDataPackageChange',
           {
             masterId: result.dataPackage.masterId,
-            projectId: result.dataAcquisitionProjectId
+            projectId: result.dataAcquisitionProjectId,
+            version: _.get(result, 'release.version')
           });
+        MessageBus.set('onDetailViewLoaded', {type: 'dataPackage'});
       }
       if (result.repeatedMeasurementIdentifier) {
         VariableRepositoryClient
@@ -237,4 +239,3 @@ angular.module('metadatamanagementApp')
       }
     };
   }]);
-


### PR DESCRIPTION
## Summary

- Pass the resolved data package release version into the order sidebar configurator
- Allow detail-page/sidebar lookups to load hidden shadow copies when opening known package links
- Initialize the data package order sidebar from variable, data set, question, instrument, and survey detail pages in public/order view

## Motivation

Following a DOI link to a hidden data package correctly opens the landing page, but the order sidebar remains empty. The detail page can resolve the hidden released package, while the sidebar performs a separate lookup that can lose the release version or filter out hidden shadow copies.

The same issue can appear on product detail pages because they did not consistently initialize the data package configurator in order view.

## Verification

<img width="1726" height="938" alt="Screenshot 2026-04-21 at 14 49 50" src="https://github.com/user-attachments/assets/0eaa3c5e-4a6e-42f9-99fe-bbdb0e5e6c9c" />
 
<img width="1726" height="938" alt="Screenshot 2026-04-21 at 14 33 29" src="https://github.com/user-attachments/assets/6b669473-4f72-4d33-8a0e-c99c4247ed15" />


