### PR TITLE
Display keyword sections in collapsible preview

### DIFF
--- a/mdm-frontend/src/app/legacy/analysispackagemanagement/views/analysis-package-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/analysispackagemanagement/views/analysis-package-detail.controller.js
@@ -87,6 +87,7 @@ angular.module('metadatamanagementApp')
         }
       };
       var ctrl = this;
+      var KEYWORD_PREVIEW_LIMIT = 10;
       var bowser = $rootScope.bowser;
 
       ctrl.dataPackageList = {
@@ -107,12 +108,38 @@ angular.module('metadatamanagementApp')
       ctrl.scriptAttachments = [];
       ctrl.isAuthenticated = Principal.isAuthenticated;
       ctrl.hasAuthority = Principal.hasAuthority;
+      ctrl.keywordSectionsExpanded = {};
       ctrl.searchResultIndex = SearchResultNavigatorService.getSearchIndex();
       ctrl.counts = {
         publicationsCount: 0
       };
       ctrl.enableJsonView = Principal
         .hasAnyAuthority(['ROLE_PUBLISHER', 'ROLE_ADMIN']);
+
+      ctrl.hasKeywordToggle = function(keywords) {
+        return Array.isArray(keywords) &&
+          keywords.length > KEYWORD_PREVIEW_LIMIT;
+      };
+
+      ctrl.isKeywordSectionExpanded = function(section) {
+        return !!ctrl.keywordSectionsExpanded[section];
+      };
+
+      ctrl.getVisibleKeywords = function(section, keywords) {
+        if (!Array.isArray(keywords)) {
+          return [];
+        }
+        if (ctrl.isKeywordSectionExpanded(section) ||
+            keywords.length <= KEYWORD_PREVIEW_LIMIT) {
+          return keywords;
+        }
+        return keywords.slice(0, KEYWORD_PREVIEW_LIMIT);
+      };
+
+      ctrl.toggleKeywordSection = function(section) {
+        ctrl.keywordSectionsExpanded[section] =
+          !ctrl.keywordSectionsExpanded[section];
+      };
 
       /**
        * Method for loading attachments
@@ -350,4 +377,3 @@ angular.module('metadatamanagementApp')
         })
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/analysispackagemanagement/views/analysis-package-detail.html.tmpl
+++ b/mdm-frontend/src/app/legacy/analysispackagemanagement/views/analysis-package-detail.html.tmpl
@@ -12,70 +12,102 @@
                                  header-title="ctrl.analysisPackage.title" ng-if="ctrl.enableJsonView"></json-content-dialog>
           </div>
           <div class="fdz-tag-link-container" ng-if="ctrl.analysisPackageTags.length > 0">
-            <h5>{{'analysis-package-management.detail.label.tags' | translate}}: </h5>
-            <a ng-repeat="tag in ctrl.analysisPackageTags"
-               ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
-               ui-sref="searchReleased({type: 'analysis_packages', 'tags': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'analysis-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <a ng-repeat="tag in ctrl.analysisPackageTags"
-               ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
-               ui-sref="search({type: 'analysis_packages', 'query': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'analysis-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <a ng-repeat="tag in ctrl.analysisPackageTags"
-               ng-if="!ctrl.isAuthenticated()"
-               ui-sref="search({type: 'analysis_packages', 'tags': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'analysis-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
+            <div class="fdz-keyword-section">
+              <div class="fdz-keyword-label">
+                <h5>{{'analysis-package-management.detail.label.tags' | translate}}: </h5>
+              </div>
+              <div class="fdz-keyword-row">
+                <div class="fdz-keyword-list">
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.analysisPackageTags)"
+                     ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                     ui-sref="searchReleased({type: 'analysis_packages', 'tags': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'analysis-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.analysisPackageTags)"
+                     ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                     ui-sref="search({type: 'analysis_packages', 'query': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'analysis-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.analysisPackageTags)"
+                     ng-if="!ctrl.isAuthenticated()"
+                     ui-sref="search({type: 'analysis_packages', 'tags': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'analysis-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                </div>
+                <md-button class="md-primary fdz-keyword-toggle"
+                           ng-if="ctrl.hasKeywordToggle(ctrl.analysisPackageTags)"
+                           ng-click="ctrl.toggleKeywordSection('tags')"
+                           aria-expanded="{{ctrl.isKeywordSectionExpanded('tags')}}">
+                  <md-icon md-font-set="material-icons">
+                    {{ctrl.isKeywordSectionExpanded('tags') ? 'expand_less' : 'expand_more'}}
+                  </md-icon>
+                  <span>
+                    {{(ctrl.isKeywordSectionExpanded('tags') ? 'global.buttons.show-less' : 'global.buttons.show-more') | translate}}
+                  </span>
+                </md-button>
+              </div>
+            </div>
           </div>
           <!-- ELSST tags -->
           <div class="fdz-tag-link-container" ng-if="ctrl.analysisPackageTagsElsst.length > 0">
-            <div style="display: flex; flex-direction: row; justify-items: flex-start; align-items: first baseline;">
-              <div style="width: 165px;">
+            <div class="fdz-keyword-section">
+              <div class="fdz-keyword-label">
                 <h5>{{'analysis-package-management.detail.label.tagsElsst' | translate}}</h5>
-                <md-button class="md-primary md-icon-button" style="margin-left: -10px; padding: 2px 0px 0px 0px; margin-right: -5px; width: fit-content; padding-bottom: 0%;" ng-click="ctrl.infoModal($event)">
-                  <md-icon style="margin: 0px; font-size: 20px">info</md-icon>
+                <md-button class="md-primary md-icon-button fdz-keyword-info-button" ng-click="ctrl.infoModal($event)">
+                  <md-icon>info</md-icon>
                   <md-tooltip md-direction="top" md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'data-package-management.detail.elsst-general-tooltip' | translate}}
                   </md-tooltip>
                 </md-button>
                 <h5>: </h5>
               </div>
-              <div>
-                <a ng-repeat="tagElsst in ctrl.analysisPackageTagsElsst"
-                  ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
-                  ui-sref="searchReleased({type: 'analysis_packages', 'tagsElsst': tagElsst.prefLabel})">
-                  <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'analysis-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
-                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
-                    ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
-                    ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})">
+              <div class="fdz-keyword-row">
+                <div class="fdz-keyword-list">
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.analysisPackageTagsElsst)"
+                    ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                    ui-sref="searchReleased({type: 'analysis_packages', 'tagsElsst': tagElsst.prefLabel})">
                     <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
-                <a ng-repeat="tagElsst in ctrl.analysisPackageTagsElsst"
-                  ng-if="!ctrl.isAuthenticated()"
-                  ui-sref="search({type: 'analysis_packages', 'tagsElsst': tagElsst.prefLabel})">
-                  <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'analysis-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'analysis-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.analysisPackageTagsElsst)"
+                      ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                      ui-sref="search({type: 'analysis_packages', 'query': tagElsst.prefLabel})">
+                      <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.analysisPackageTagsElsst)"
+                    ng-if="!ctrl.isAuthenticated()"
+                    ui-sref="search({type: 'analysis_packages', 'tagsElsst': tagElsst.prefLabel})">
+                    <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'analysis-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                </div>
+                <md-button class="md-primary fdz-keyword-toggle"
+                           ng-if="ctrl.hasKeywordToggle(ctrl.analysisPackageTagsElsst)"
+                           ng-click="ctrl.toggleKeywordSection('tagsElsst')"
+                           aria-expanded="{{ctrl.isKeywordSectionExpanded('tagsElsst')}}">
+                  <md-icon md-font-set="material-icons">
+                    {{ctrl.isKeywordSectionExpanded('tagsElsst') ? 'expand_less' : 'expand_more'}}
+                  </md-icon>
+                  <span>
+                    {{(ctrl.isKeywordSectionExpanded('tagsElsst') ? 'global.buttons.show-less' : 'global.buttons.show-more') | translate}}
+                  </span>
+                </md-button>
               </div>
             </div>
           </div>

--- a/mdm-frontend/src/app/legacy/common/i18n/configuration/translations-de.js
+++ b/mdm-frontend/src/app/legacy/common/i18n/configuration/translations-de.js
@@ -97,6 +97,8 @@ angular.module('metadatamanagementApp').config([
           'ok': 'OK',
           'save': 'Speichern',
           'cancel': 'Abbrechen',
+          'show-more': 'Mehr anzeigen',
+          'show-less': 'Weniger anzeigen',
           'closeDialogTemporarily': 'Jetzt nicht!'
         },
         'tooltips': {

--- a/mdm-frontend/src/app/legacy/common/i18n/configuration/translations-en.js
+++ b/mdm-frontend/src/app/legacy/common/i18n/configuration/translations-en.js
@@ -97,6 +97,8 @@ angular.module('metadatamanagementApp').config([
           'ok': 'OK',
           'save': 'Save',
           'cancel': 'Cancel',
+          'show-more': 'Show more',
+          'show-less': 'Show less',
           'closeDialogTemporarily': 'Not yet!'
         },
         'tooltips': {

--- a/mdm-frontend/src/app/legacy/conceptmanagement/views/concept-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/conceptmanagement/views/concept-detail.controller.js
@@ -43,8 +43,10 @@ angular.module('metadatamanagementApp')
       };
 
       var ctrl = this;
+      var KEYWORD_PREVIEW_LIMIT = 10;
       ctrl.isAuthenticated = Principal.isAuthenticated;
       ctrl.hasAuthority = Principal.hasAuthority;
+      ctrl.keywordSectionsExpanded = {};
       ctrl.searchResultIndex = SearchResultNavigatorService.getSearchIndex();
       ctrl.counts = {
         dataPackagesCount: 0,
@@ -57,6 +59,31 @@ angular.module('metadatamanagementApp')
 
       ctrl.enableJsonView = Principal
         .hasAnyAuthority(['ROLE_PUBLISHER', 'ROLE_ADMIN']);
+
+      ctrl.hasKeywordToggle = function(keywords) {
+        return Array.isArray(keywords) &&
+          keywords.length > KEYWORD_PREVIEW_LIMIT;
+      };
+
+      ctrl.isKeywordSectionExpanded = function(section) {
+        return !!ctrl.keywordSectionsExpanded[section];
+      };
+
+      ctrl.getVisibleKeywords = function(section, keywords) {
+        if (!Array.isArray(keywords)) {
+          return [];
+        }
+        if (ctrl.isKeywordSectionExpanded(section) ||
+            keywords.length <= KEYWORD_PREVIEW_LIMIT) {
+          return keywords;
+        }
+        return keywords.slice(0, KEYWORD_PREVIEW_LIMIT);
+      };
+
+      ctrl.toggleKeywordSection = function(section) {
+        ctrl.keywordSectionsExpanded[section] =
+          !ctrl.keywordSectionsExpanded[section];
+      };
 
       ctrl.loadAttachments = function() {
         ConceptAttachmentResource.findByConceptId({
@@ -112,4 +139,3 @@ angular.module('metadatamanagementApp')
         });
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/conceptmanagement/views/concept-detail.html.tmpl
+++ b/mdm-frontend/src/app/legacy/conceptmanagement/views/concept-detail.html.tmpl
@@ -11,76 +11,108 @@
                                  header-title="ctrl.concept.title" ng-if="ctrl.enableJsonView"></json-content-dialog>
           </div>
           <div class="fdz-tag-link-container" ng-if="ctrl.conceptTags.length > 0">
-            <h5>{{'data-package-management.detail.label.tags' | translate}}: </h5>
-            <!-- When in order view search for data packages as concepts cannot be searched from that view -->
-            <a ng-repeat="tag in ctrl.conceptTags"
-               ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
-               ui-sref="searchReleased({type: 'data_packages', 'query': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <!-- When in provider view search for concepts -->
-            <a ng-repeat="tag in ctrl.conceptTags"
-               ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
-               ui-sref="search({type: 'concepts', 'query': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <!-- When in unauthenticated order view search for data packages as concepts cannot be searched from that view -->
-            <a ng-repeat="tag in ctrl.conceptTags"
-               ng-if="!ctrl.isAuthenticated()"
-               ui-sref="search({type: 'data_packages', 'query': tag})" rel="nofollow">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
+            <div class="fdz-keyword-section">
+              <div class="fdz-keyword-label">
+                <h5>{{'data-package-management.detail.label.tags' | translate}}: </h5>
+              </div>
+              <div class="fdz-keyword-row">
+                <div class="fdz-keyword-list">
+                  <!-- When in order view search for data packages as concepts cannot be searched from that view -->
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.conceptTags)"
+                     ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                     ui-sref="searchReleased({type: 'data_packages', 'query': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <!-- When in provider view search for concepts -->
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.conceptTags)"
+                     ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                     ui-sref="search({type: 'concepts', 'query': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <!-- When in unauthenticated order view search for data packages as concepts cannot be searched from that view -->
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.conceptTags)"
+                     ng-if="!ctrl.isAuthenticated()"
+                     ui-sref="search({type: 'data_packages', 'query': tag})" rel="nofollow">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                </div>
+                <md-button class="md-primary fdz-keyword-toggle"
+                           ng-if="ctrl.hasKeywordToggle(ctrl.conceptTags)"
+                           ng-click="ctrl.toggleKeywordSection('tags')"
+                           aria-expanded="{{ctrl.isKeywordSectionExpanded('tags')}}">
+                  <md-icon md-font-set="material-icons">
+                    {{ctrl.isKeywordSectionExpanded('tags') ? 'expand_less' : 'expand_more'}}
+                  </md-icon>
+                  <span>
+                    {{(ctrl.isKeywordSectionExpanded('tags') ? 'global.buttons.show-less' : 'global.buttons.show-more') | translate}}
+                  </span>
+                </md-button>
+              </div>
+            </div>
           </div>
           <!-- ELSST tags -->
           <div class="fdz-tag-link-container" ng-if="ctrl.conceptTagsElsst.length > 0">
-            <div style="display: flex; flex-direction: row; justify-items: flex-start; align-items: first baseline;">
-              <div style="width: 165px;">
+            <div class="fdz-keyword-section">
+              <div class="fdz-keyword-label">
                 <h5>{{'data-package-management.detail.label.tagsElsst' | translate}}</h5>
-                <md-button class="md-primary md-icon-button" style="margin-left: -10px; padding: 2px 0px 0px 0px; margin-right: -5px; width: fit-content; padding-bottom: 0%;" ng-click="ctrl.infoModal($event)">
-                  <md-icon style="margin: 0px; font-size: 20px">info</md-icon>
+                <md-button class="md-primary md-icon-button fdz-keyword-info-button" ng-click="ctrl.infoModal($event)">
+                  <md-icon>info</md-icon>
                   <md-tooltip md-direction="top" md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'data-package-management.detail.elsst-general-tooltip' | translate}}
                   </md-tooltip>
                 </md-button>
                 <h5>: </h5>
               </div>
-              <div>
-                <!-- When in order view search for data packages as concepts cannot be searched from that view -->
-                <a ng-repeat="tagElsst in ctrl.conceptTagsElsst"
-                  ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
-                  ui-sref="searchReleased({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
-                  <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
-                <!-- When in provider view search for concepts -->
-                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
-                    ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
-                    ui-sref="search({type: 'concepts', 'query': tagElsst.prefLabel})">
+              <div class="fdz-keyword-row">
+                <div class="fdz-keyword-list">
+                  <!-- When in order view search for data packages as concepts cannot be searched from that view -->
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.conceptTagsElsst)"
+                    ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                    ui-sref="searchReleased({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
                     <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
-                <!-- When in unauthenticated order view search for data packages as concepts cannot be searched from that view -->
-                <a ng-repeat="tagElsst in ctrl.conceptTagsElsst"
-                  ng-if="!ctrl.isAuthenticated()"
-                  ui-sref="search({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})" rel="nofollow">
-                  <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <!-- When in provider view search for concepts -->
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.conceptTagsElsst)"
+                      ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                      ui-sref="search({type: 'concepts', 'query': tagElsst.prefLabel})">
+                      <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <!-- When in unauthenticated order view search for data packages as concepts cannot be searched from that view -->
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.conceptTagsElsst)"
+                    ng-if="!ctrl.isAuthenticated()"
+                    ui-sref="search({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})" rel="nofollow">
+                    <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                </div>
+                <md-button class="md-primary fdz-keyword-toggle"
+                           ng-if="ctrl.hasKeywordToggle(ctrl.conceptTagsElsst)"
+                           ng-click="ctrl.toggleKeywordSection('tagsElsst')"
+                           aria-expanded="{{ctrl.isKeywordSectionExpanded('tagsElsst')}}">
+                  <md-icon md-font-set="material-icons">
+                    {{ctrl.isKeywordSectionExpanded('tagsElsst') ? 'expand_less' : 'expand_more'}}
+                  </md-icon>
+                  <span>
+                    {{(ctrl.isKeywordSectionExpanded('tagsElsst') ? 'global.buttons.show-less' : 'global.buttons.show-more') | translate}}
+                  </span>
+                </md-button>
               </div>
             </div>
           </div>

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.controller.js
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.controller.js
@@ -76,8 +76,10 @@ angular.module('metadatamanagementApp')
         }
       };
       var ctrl = this;
+      var KEYWORD_PREVIEW_LIMIT = 10;
       ctrl.isAuthenticated = Principal.isAuthenticated;
       ctrl.hasAuthority = Principal.hasAuthority;
+      ctrl.keywordSectionsExpanded = {};
       ctrl.projectIsCurrentlyReleased = true;
       ctrl.searchResultIndex = SearchResultNavigatorService.getSearchIndex();
       ctrl.counts = {
@@ -93,6 +95,31 @@ angular.module('metadatamanagementApp')
         .hasAnyAuthority(['ROLE_PUBLISHER', 'ROLE_ADMIN']);
       ctrl.showRemarks = Principal
         .hasAnyAuthority(['ROLE_PUBLISHER']);
+
+      ctrl.hasKeywordToggle = function(keywords) {
+        return Array.isArray(keywords) &&
+          keywords.length > KEYWORD_PREVIEW_LIMIT;
+      };
+
+      ctrl.isKeywordSectionExpanded = function(section) {
+        return !!ctrl.keywordSectionsExpanded[section];
+      };
+
+      ctrl.getVisibleKeywords = function(section, keywords) {
+        if (!Array.isArray(keywords)) {
+          return [];
+        }
+        if (ctrl.isKeywordSectionExpanded(section) ||
+            keywords.length <= KEYWORD_PREVIEW_LIMIT) {
+          return keywords;
+        }
+        return keywords.slice(0, KEYWORD_PREVIEW_LIMIT);
+      };
+
+      ctrl.toggleKeywordSection = function(section) {
+        ctrl.keywordSectionsExpanded[section] =
+          !ctrl.keywordSectionsExpanded[section];
+      };
 
       var bowser = $rootScope.bowser;
 
@@ -343,4 +370,3 @@ angular.module('metadatamanagementApp')
         });
       };
     }]);
-

--- a/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.html.tmpl
+++ b/mdm-frontend/src/app/legacy/datapackagemanagement/views/data-package-detail.html.tmpl
@@ -12,70 +12,102 @@
               header-title="ctrl.dataPackage.title" ng-if="ctrl.enableJsonView"></json-content-dialog>
           </div>
           <div class="fdz-tag-link-container" ng-if="ctrl.dataPackageTags.length > 0">
-            <h5>{{'data-package-management.detail.label.tags' | translate}}: </h5>
-            <a ng-repeat="tag in ctrl.dataPackageTags"
-               ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
-               ui-sref="searchReleased({type: 'data_packages', 'tags': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <a ng-repeat="tag in ctrl.dataPackageTags"
-               ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
-               ui-sref="search({type: 'data_packages', 'query': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
-            <a ng-repeat="tag in ctrl.dataPackageTags"
-               ng-if="!ctrl.isAuthenticated()"
-               ui-sref="search({type: 'data_packages', 'tags': tag})">
-              <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
-              <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                {{'data-package-management.detail.tag-tooltip' | translate}}
-              </md-tooltip>
-            </a>
+            <div class="fdz-keyword-section">
+              <div class="fdz-keyword-label">
+                <h5>{{'data-package-management.detail.label.tags' | translate}}: </h5>
+              </div>
+              <div class="fdz-keyword-row">
+                <div class="fdz-keyword-list">
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.dataPackageTags)"
+                     ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                     ui-sref="searchReleased({type: 'data_packages', 'tags': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.dataPackageTags)"
+                     ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                     ui-sref="search({type: 'data_packages', 'query': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tag in ctrl.getVisibleKeywords('tags', ctrl.dataPackageTags)"
+                     ng-if="!ctrl.isAuthenticated()"
+                     ui-sref="search({type: 'data_packages', 'tags': tag})">
+                    <span>{{tag}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tag-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                </div>
+                <md-button class="md-primary fdz-keyword-toggle"
+                           ng-if="ctrl.hasKeywordToggle(ctrl.dataPackageTags)"
+                           ng-click="ctrl.toggleKeywordSection('tags')"
+                           aria-expanded="{{ctrl.isKeywordSectionExpanded('tags')}}">
+                  <md-icon md-font-set="material-icons">
+                    {{ctrl.isKeywordSectionExpanded('tags') ? 'expand_less' : 'expand_more'}}
+                  </md-icon>
+                  <span>
+                    {{(ctrl.isKeywordSectionExpanded('tags') ? 'global.buttons.show-less' : 'global.buttons.show-more') | translate}}
+                  </span>
+                </md-button>
+              </div>
+            </div>
           </div>
           <!-- ELSST tags -->
           <div class="fdz-tag-link-container" ng-if="ctrl.dataPackageTagsElsst.length > 0">
-            <div style="display: flex; flex-direction: row; justify-items: flex-start; align-items: first baseline;">
-              <div style="width: 195px;">
+            <div class="fdz-keyword-section">
+              <div class="fdz-keyword-label">
                 <h5>{{'data-package-management.detail.label.tagsElsst' | translate}}</h5>
-                <md-button class="md-primary md-icon-button" style="margin-left: -10px; padding: 2px 0px 0px 0px; margin-right: -5px; width: fit-content; padding-bottom: 0%;" ng-click="ctrl.infoModal($event)">
-                  <md-icon style="margin: 0px; font-size: 20px">info</md-icon>
+                <md-button class="md-primary md-icon-button fdz-keyword-info-button" ng-click="ctrl.infoModal($event)">
+                  <md-icon>info</md-icon>
                   <md-tooltip md-direction="top" md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
                     {{'data-package-management.detail.elsst-general-tooltip' | translate}}
                   </md-tooltip>
                 </md-button>
                 <h5>: </h5>
               </div>
-              <div>
-                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
-                    ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
-                    ui-sref="searchReleased({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
+              <div class="fdz-keyword-row">
+                <div class="fdz-keyword-list">
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.dataPackageTagsElsst)"
+                      ng-if="ctrl.isAuthenticated() && !ctrl.isProviderView"
+                      ui-sref="searchReleased({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
+                      <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.dataPackageTagsElsst)"
+                      ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
+                      ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})">
+                      <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                  <a ng-repeat="tagElsst in ctrl.getVisibleKeywords('tagsElsst', ctrl.dataPackageTagsElsst)"
+                      ng-if="!ctrl.isAuthenticated()"
+                      ui-sref="search({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
                     <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
-                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
-                    ng-if="ctrl.isAuthenticated() && ctrl.isProviderView"
-                    ui-sref="search({type: 'data_packages', 'query': tagElsst.prefLabel})">
-                    <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
-                <a ng-repeat="tagElsst in ctrl.dataPackageTagsElsst"
-                    ng-if="!ctrl.isAuthenticated()"
-                    ui-sref="search({type: 'data_packages', 'tagsElsst': tagElsst.prefLabel})">
-                  <span>{{tagElsst.prefLabel}}{{!$last?',&nbsp;':''}}</span>
-                  <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
-                    {{'data-package-management.detail.tagElsst-tooltip' | translate}}
-                  </md-tooltip>
-                </a>
+                    <md-tooltip md-autohide="true" md-z-index="bowser.mobile || bowser.tablet ? -100 : 100001">
+                      {{'data-package-management.detail.tagElsst-tooltip' | translate}}
+                    </md-tooltip>
+                  </a>
+                </div>
+                <md-button class="md-primary fdz-keyword-toggle"
+                           ng-if="ctrl.hasKeywordToggle(ctrl.dataPackageTagsElsst)"
+                           ng-click="ctrl.toggleKeywordSection('tagsElsst')"
+                           aria-expanded="{{ctrl.isKeywordSectionExpanded('tagsElsst')}}">
+                  <md-icon md-font-set="material-icons">
+                    {{ctrl.isKeywordSectionExpanded('tagsElsst') ? 'expand_less' : 'expand_more'}}
+                  </md-icon>
+                  <span>
+                    {{(ctrl.isKeywordSectionExpanded('tagsElsst') ? 'global.buttons.show-less' : 'global.buttons.show-more') | translate}}
+                  </span>
+                </md-button>
               </div>
             </div>
           </div>

--- a/mdm-frontend/src/scss/fdz-theme/components/fdz/detail-theme.scss
+++ b/mdm-frontend/src/scss/fdz-theme/components/fdz/detail-theme.scss
@@ -37,14 +37,14 @@ $card-border-radius: 2px !default;
   }
 
   .fdz-tag-link-container {
-    display: inline;
+    display: block;
     align-items: baseline;
     width: 100%;
 
     h5 {
       color: $foreground-3;
       margin-right: 8px;
-      display: inline-flex
+      display: inline-flex;
     }
 
     a {
@@ -52,6 +52,80 @@ $card-border-radius: 2px !default;
       min-height: auto;
       min-width: auto;
       font-size: 100%;
+    }
+
+    .fdz-keyword-section {
+      align-items: stretch;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      width: 100%;
+    }
+
+    .fdz-keyword-label {
+      align-items: center;
+      display: inline-flex;
+      flex: 0 0 auto;
+      white-space: nowrap;
+
+      h5 {
+        margin: 0;
+      }
+    }
+
+    .fdz-keyword-info-button {
+      align-items: center;
+      display: inline-flex;
+      height: auto;
+      margin: 0 2px;
+      min-height: auto;
+      min-width: auto;
+      padding: 0;
+      justify-content: center;
+      line-height: 20px;
+      width: auto;
+
+      md-icon {
+        font-size: 20px;
+        height: 20px;
+        line-height: 20px;
+        margin: 0;
+        width: 20px;
+      }
+    }
+
+    .fdz-keyword-row {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .fdz-keyword-list {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .fdz-keyword-toggle {
+      flex: 0 0 auto;
+      font-weight: 600;
+      line-height: inherit;
+      margin: 0;
+      min-height: auto;
+      min-width: auto;
+      padding: 0 2px;
+      text-transform: none;
+
+      md-icon {
+        font-size: 18px;
+        height: 18px;
+        line-height: 18px;
+        margin: 0 2px 0 0;
+        min-height: auto;
+        min-width: auto;
+        width: 18px;
+      }
     }
   }
   .fdz-detail__content {


### PR DESCRIPTION
## Changes

- Shows only the first 10 entries by default for `Keywords` and `ELSST Keywords`.
- Adds independent `Show more` / `Show less` toggles for each keyword section.
- Hides the toggle when a section has 10 or fewer keywords.
- Keeps the existing keyword data structures unchanged.
- Applies the behavior consistently to:
  - data package detail pages
  - analysis package detail pages
  - concept detail pages
- Keeps keyword labels above the keyword list.
- Keeps the ELSST info icon compact and vertically centered.
- Fixes ELSST keyword rendering in analysis package and concept provider views by using the correct ELSST tag arrays.

## Verification
<img width="1626" height="665" alt="Screenshot 2026-04-22 at 10 46 40" src="https://github.com/user-attachments/assets/926676e2-04ae-48e0-8e9e-289173271538" />
<img width="1626" height="665" alt="Screenshot 2026-04-22 at 10 46 47" src="https://github.com/user-attachments/assets/abb4465f-2d39-445b-8b8e-a48902f96899" />
<img width="1626" height="665" alt="Screenshot 2026-04-22 at 10 47 10" src="https://github.com/user-attachments/assets/a8ae6897-3777-462c-86ec-0622b729ab37" />
