### PR TITLE
3478 version is displayed twice in the order panel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3.10"
 services:
   mongodb:
-    image: mongo:latest
+    image: mongo:6.0
     container_name: mongodb
     environment:
       - MONGO_DATA_DIR=/data/mongodb/data

--- a/mdm-frontend/src/app/legacy/ordermanagement/components/data-package-configurator.controller.js
+++ b/mdm-frontend/src/app/legacy/ordermanagement/components/data-package-configurator.controller.js
@@ -121,7 +121,7 @@
           var releaseList = [];
           for (var release of releases) {
               // only allow fully released versions to be listed for ordering
-              if (!release.isPreRelease) {
+              if (!release.isPreRelease && releaseList.findIndex(r => r.version === release.version) === -1) {
                 releaseList.push(release);
               }
           }

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <dependency>
             <groupId>pl.allegro.tech</groupId>
             <artifactId>embedded-elasticsearch</artifactId>
-            <version>2.11.3</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <!-- tweet okhttp3 -->

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -33,7 +33,7 @@ spring:
       resources:
         static-locations:
           - file:src/main/webapp/
-          - classpath:public/
+          - classpath:dist/
 
 mongock:
     enabled: true


### PR DESCRIPTION
#3478 

Reason: Data Packages are saved even if they are already released if you are adding a publisher. During saving, in release also the latest entry is getting a release entry from the latest version. Hence two entry exists with latest version. 

Solution: To not change whole data, the version is only added once in combo box. It needs to be discussed, if further changes are needed.